### PR TITLE
Document the required composer install step for Git installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ by calling:
 git clone https://github.com/magicsunday/webtrees-descendants-chart.git modules_v4/webtrees-descendants-chart
 ```
 
+A Git checkout contains the source code only — it does **not** include the bundled
+`vendor/` dependencies. After cloning, install them from inside the module directory
+(this requires [Composer](https://getcomposer.org/) and a PHP CLI on the host):
+
+```shell
+cd modules_v4/webtrees-descendants-chart
+composer install --no-dev
+```
+
+> [!IMPORTANT]
+> Without this step the module aborts on every page with a
+> `Trait "MagicSunday\Webtrees\ModuleBase\…" not found` fatal error, because the
+> shared `webtrees-module-base` dependency is missing from `vendor/`. If you cannot
+> run Composer on your server, use the [asset zip](#manual-installation) instead.
+
 Then follow the steps described in [configuration](#configuration) and [usage](#usage).
 
 


### PR DESCRIPTION
## Problem

The **Using Git** install section told users to `git clone` the module into `modules_v4/`, but a bare clone ships the source **without** the bundled `vendor/` dependencies. Because `module.php` registers `MagicSunday\Webtrees\ModuleBase\` → `./vendor/magicsunday/webtrees-module-base/src`, the page then aborts with:

> Fatal error: Trait "MagicSunday\Webtrees\ModuleBase\Traits\…" not found

Anyone trying to test the current `main` branch via Git hits this.

## Change

Add the mandatory `composer install --no-dev` step to the **Using Git** section, with a fallback note pointing users who cannot run Composer on their server to the ready-to-use asset zip.

Mirrors the same fix in webtrees-statistics. Docs-only; no code or behaviour change.