### PR TITLE
GH-112: Forward the display settings through the re-centering URL

### DIFF
--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Nejprve zkrátit křestní jména"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Nejprve zkrátit příjmení"
 
@@ -32,7 +32,7 @@ msgstr "Nejprve zkrátit příjmení"
 msgid "An overview of an individual’s descendants."
 msgstr "Přehled potomků osoby."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automaticky (podle tradice příjmení stromu)"
 
@@ -40,11 +40,11 @@ msgstr "Automaticky (podle tradice příjmení stromu)"
 msgid "Behavior"
 msgstr "Chování"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Pouze rodné jméno"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Rodné jméno se jménem po sňatku v závorkách"
 
@@ -132,7 +132,7 @@ msgstr ""
 "Martin \"Chalky\" White). Napodobuje původní chování webtrees pro stromy, "
 "které přezdívky ukládají do samostatného pole GEDCOM NICK."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Pouze jméno po sňatku"
 

--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Nejprve zkrátit křestní jména"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Nejprve zkrátit příjmení"
 
@@ -32,7 +32,7 @@ msgstr "Nejprve zkrátit příjmení"
 msgid "An overview of an individual’s descendants."
 msgstr "Přehled potomků osoby."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automaticky (podle tradice příjmení stromu)"
 
@@ -40,11 +40,11 @@ msgstr "Automaticky (podle tradice příjmení stromu)"
 msgid "Behavior"
 msgstr "Chování"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Pouze rodné jméno"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Rodné jméno se jménem po sňatku v závorkách"
 
@@ -132,7 +132,7 @@ msgstr ""
 "Martin \"Chalky\" White). Napodobuje původní chování webtrees pro stromy, "
 "které přezdívky ukládají do samostatného pole GEDCOM NICK."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Pouze jméno po sňatku"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "zrušit"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "dolů"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "vlevo"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "vpravo"
 
@@ -231,7 +231,7 @@ msgstr "vpravo"
 msgid "save"
 msgstr "uložit"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "nahoru"
 

--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Nejprve zkrátit křestní jména"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Nejprve zkrátit příjmení"
 
@@ -32,7 +32,7 @@ msgstr "Nejprve zkrátit příjmení"
 msgid "An overview of an individual’s descendants."
 msgstr "Přehled potomků osoby."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automaticky (podle tradice příjmení stromu)"
 
@@ -40,11 +40,11 @@ msgstr "Automaticky (podle tradice příjmení stromu)"
 msgid "Behavior"
 msgstr "Chování"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Pouze rodné jméno"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Rodné jméno se jménem po sňatku v závorkách"
 
@@ -132,7 +132,7 @@ msgstr ""
 "Martin \"Chalky\" White). Napodobuje původní chování webtrees pro stromy, "
 "které přezdívky ukládají do samostatného pole GEDCOM NICK."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Pouze jméno po sňatku"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "zrušit"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "dolů"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "vlevo"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "vpravo"
 
@@ -231,7 +231,7 @@ msgstr "vpravo"
 msgid "save"
 msgstr "uložit"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "nahoru"
 

--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Nejprve zkrátit křestní jména"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Nejprve zkrátit příjmení"
 
@@ -32,7 +32,7 @@ msgstr "Nejprve zkrátit příjmení"
 msgid "An overview of an individual’s descendants."
 msgstr "Přehled potomků osoby."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automaticky (podle tradice příjmení stromu)"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "zrušit"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "dolů"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "vlevo"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "vpravo"
 
@@ -231,7 +231,7 @@ msgstr "vpravo"
 msgid "save"
 msgstr "uložit"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "nahoru"
 

--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Nejprve zkrátit křestní jména"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Nejprve zkrátit příjmení"
 
@@ -32,7 +32,7 @@ msgstr "Nejprve zkrátit příjmení"
 msgid "An overview of an individual’s descendants."
 msgstr "Přehled potomků osoby."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automaticky (podle tradice příjmení stromu)"
 
@@ -40,11 +40,11 @@ msgstr "Automaticky (podle tradice příjmení stromu)"
 msgid "Behavior"
 msgstr "Chování"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Pouze rodné jméno"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Rodné jméno se jménem po sňatku v závorkách"
 
@@ -132,7 +132,7 @@ msgstr ""
 "Martin \"Chalky\" White). Napodobuje původní chování webtrees pro stromy, "
 "které přezdívky ukládají do samostatného pole GEDCOM NICK."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Pouze jméno po sňatku"
 

--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Nejprve zkrátit křestní jména"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Nejprve zkrátit příjmení"
 
@@ -32,7 +32,7 @@ msgstr "Nejprve zkrátit příjmení"
 msgid "An overview of an individual’s descendants."
 msgstr "Přehled potomků osoby."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automaticky (podle tradice příjmení stromu)"
 
@@ -40,11 +40,11 @@ msgstr "Automaticky (podle tradice příjmení stromu)"
 msgid "Behavior"
 msgstr "Chování"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Pouze rodné jméno"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Rodné jméno se jménem po sňatku v závorkách"
 
@@ -132,7 +132,7 @@ msgstr ""
 "Martin \"Chalky\" White). Napodobuje původní chování webtrees pro stromy, "
 "které přezdívky ukládají do samostatného pole GEDCOM NICK."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Pouze jméno po sňatku"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "zrušit"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "dolů"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "vlevo"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "vpravo"
 
@@ -231,7 +231,7 @@ msgstr "vpravo"
 msgid "save"
 msgstr "uložit"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "nahoru"
 

--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Nejprve zkrátit křestní jména"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Nejprve zkrátit příjmení"
 
@@ -32,7 +32,7 @@ msgstr "Nejprve zkrátit příjmení"
 msgid "An overview of an individual’s descendants."
 msgstr "Přehled potomků osoby."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automaticky (podle tradice příjmení stromu)"
 
@@ -40,11 +40,11 @@ msgstr "Automaticky (podle tradice příjmení stromu)"
 msgid "Behavior"
 msgstr "Chování"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Pouze rodné jméno"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Rodné jméno se jménem po sňatku v závorkách"
 
@@ -132,7 +132,7 @@ msgstr ""
 "Martin \"Chalky\" White). Napodobuje původní chování webtrees pro stromy, "
 "které přezdívky ukládají do samostatného pole GEDCOM NICK."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Pouze jméno po sňatku"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "zrušit"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "dolů"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "vlevo"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "vpravo"
 
@@ -231,7 +231,7 @@ msgstr "vpravo"
 msgid "save"
 msgstr "uložit"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "nahoru"
 

--- a/resources/lang/da/messages.po
+++ b/resources/lang/da/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavne først"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Forkort efternavne først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort efternavne først"
 msgid "An overview of an individual’s descendants."
 msgstr "En oversigt over en persons efterkommere."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (baseret på træets efternavnstradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (baseret på træets efternavnstradition)"
 msgid "Behavior"
 msgstr "Adfærd"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Kun fødselsnavn"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Fødselsnavn med gifteenavn i parentes"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(f.eks. Martin \"Chalky\" White). Efterligner den tidligere webtrees-adfærd "
 "for træer, der gemmer kælenavne i det separate GEDCOM NICK-felt."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Kun gifteenavn"
 

--- a/resources/lang/da/messages.po
+++ b/resources/lang/da/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavne først"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Forkort efternavne først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort efternavne først"
 msgid "An overview of an individual’s descendants."
 msgstr "En oversigt over en persons efterkommere."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (baseret på træets efternavnstradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (baseret på træets efternavnstradition)"
 msgid "Behavior"
 msgstr "Adfærd"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Kun fødselsnavn"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Fødselsnavn med gifteenavn i parentes"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(f.eks. Martin \"Chalky\" White). Efterligner den tidligere webtrees-adfærd "
 "for træer, der gemmer kælenavne i det separate GEDCOM NICK-felt."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Kun gifteenavn"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "fortryd"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "højre"
 
@@ -231,7 +231,7 @@ msgstr "højre"
 msgid "save"
 msgstr "gem"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "op"
 

--- a/resources/lang/da/messages.po
+++ b/resources/lang/da/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavne først"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Forkort efternavne først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort efternavne først"
 msgid "An overview of an individual’s descendants."
 msgstr "En oversigt over en persons efterkommere."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (baseret på træets efternavnstradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (baseret på træets efternavnstradition)"
 msgid "Behavior"
 msgstr "Adfærd"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Kun fødselsnavn"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Fødselsnavn med gifteenavn i parentes"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(f.eks. Martin \"Chalky\" White). Efterligner den tidligere webtrees-adfærd "
 "for træer, der gemmer kælenavne i det separate GEDCOM NICK-felt."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Kun gifteenavn"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "fortryd"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "højre"
 
@@ -231,7 +231,7 @@ msgstr "højre"
 msgid "save"
 msgstr "gem"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "op"
 

--- a/resources/lang/da/messages.po
+++ b/resources/lang/da/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavne først"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Forkort efternavne først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort efternavne først"
 msgid "An overview of an individual’s descendants."
 msgstr "En oversigt over en persons efterkommere."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (baseret på træets efternavnstradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (baseret på træets efternavnstradition)"
 msgid "Behavior"
 msgstr "Adfærd"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Kun fødselsnavn"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Fødselsnavn med gifteenavn i parentes"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(f.eks. Martin \"Chalky\" White). Efterligner den tidligere webtrees-adfærd "
 "for træer, der gemmer kælenavne i det separate GEDCOM NICK-felt."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Kun gifteenavn"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "fortryd"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "højre"
 
@@ -231,7 +231,7 @@ msgstr "højre"
 msgid "save"
 msgstr "gem"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "op"
 

--- a/resources/lang/da/messages.po
+++ b/resources/lang/da/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavne først"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Forkort efternavne først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort efternavne først"
 msgid "An overview of an individual’s descendants."
 msgstr "En oversigt over en persons efterkommere."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (baseret på træets efternavnstradition)"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "fortryd"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "højre"
 
@@ -231,7 +231,7 @@ msgstr "højre"
 msgid "save"
 msgstr "gem"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "op"
 

--- a/resources/lang/da/messages.po
+++ b/resources/lang/da/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavne først"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Forkort efternavne først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort efternavne først"
 msgid "An overview of an individual’s descendants."
 msgstr "En oversigt over en persons efterkommere."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (baseret på træets efternavnstradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (baseret på træets efternavnstradition)"
 msgid "Behavior"
 msgstr "Adfærd"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Kun fødselsnavn"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Fødselsnavn med gifteenavn i parentes"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(f.eks. Martin \"Chalky\" White). Efterligner den tidligere webtrees-adfærd "
 "for træer, der gemmer kælenavne i det separate GEDCOM NICK-felt."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Kun gifteenavn"
 

--- a/resources/lang/da/messages.po
+++ b/resources/lang/da/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavne først"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Forkort efternavne først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort efternavne først"
 msgid "An overview of an individual’s descendants."
 msgstr "En oversigt over en persons efterkommere."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (baseret på træets efternavnstradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (baseret på træets efternavnstradition)"
 msgid "Behavior"
 msgstr "Adfærd"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Kun fødselsnavn"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Fødselsnavn med gifteenavn i parentes"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(f.eks. Martin \"Chalky\" White). Efterligner den tidligere webtrees-adfærd "
 "for træer, der gemmer kælenavne i det separate GEDCOM NICK-felt."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Kun gifteenavn"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "fortryd"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "højre"
 
@@ -231,7 +231,7 @@ msgstr "højre"
 msgid "save"
 msgstr "gem"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "op"
 

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Zuerst Vornamen abkürzen"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Zuerst Nachnamen abkürzen"
 
@@ -32,7 +32,7 @@ msgstr "Zuerst Nachnamen abkürzen"
 msgid "An overview of an individual’s descendants."
 msgstr "Ein Überblick über die Nachkommen einer Person."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 
@@ -222,15 +222,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Abbrechen"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "Unten"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "Links"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "Rechts"
 
@@ -238,7 +238,7 @@ msgstr "Rechts"
 msgid "save"
 msgstr "Speichern"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "Oben"
 

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Zuerst Vornamen abkürzen"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Zuerst Nachnamen abkürzen"
 
@@ -32,7 +32,7 @@ msgstr "Zuerst Nachnamen abkürzen"
 msgid "An overview of an individual’s descendants."
 msgstr "Ein Überblick über die Nachkommen einer Person."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 msgid "Behavior"
 msgstr "Verhalten"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Nur Geburtsname"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Geburtsname mit Ehenamen in Klammern"
 
@@ -136,7 +136,7 @@ msgstr ""
 "Verhalten für Bäume nach, die Spitznamen im separaten GEDCOM NICK-Feld "
 "speichern."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Nur Ehenamen"
 

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Zuerst Vornamen abkürzen"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Zuerst Nachnamen abkürzen"
 
@@ -32,7 +32,7 @@ msgstr "Zuerst Nachnamen abkürzen"
 msgid "An overview of an individual’s descendants."
 msgstr "Ein Überblick über die Nachkommen einer Person."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 msgid "Behavior"
 msgstr "Verhalten"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Nur Geburtsname"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Geburtsname mit Ehenamen in Klammern"
 
@@ -136,7 +136,7 @@ msgstr ""
 "Verhalten für Bäume nach, die Spitznamen im separaten GEDCOM NICK-Feld "
 "speichern."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Nur Ehenamen"
 
@@ -222,15 +222,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Abbrechen"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "Unten"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "Links"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "Rechts"
 
@@ -238,7 +238,7 @@ msgstr "Rechts"
 msgid "save"
 msgstr "Speichern"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "Oben"
 

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Zuerst Vornamen abkürzen"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Zuerst Nachnamen abkürzen"
 
@@ -32,7 +32,7 @@ msgstr "Zuerst Nachnamen abkürzen"
 msgid "An overview of an individual’s descendants."
 msgstr "Ein Überblick über die Nachkommen einer Person."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 msgid "Behavior"
 msgstr "Verhalten"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Nur Geburtsname"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Geburtsname mit Ehenamen in Klammern"
 
@@ -136,7 +136,7 @@ msgstr ""
 "Verhalten für Bäume nach, die Spitznamen im separaten GEDCOM NICK-Feld "
 "speichern."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Nur Ehenamen"
 
@@ -222,15 +222,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Abbrechen"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "Unten"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "Links"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "Rechts"
 
@@ -238,7 +238,7 @@ msgstr "Rechts"
 msgid "save"
 msgstr "Speichern"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "Oben"
 

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Zuerst Vornamen abkürzen"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Zuerst Nachnamen abkürzen"
 
@@ -32,7 +32,7 @@ msgstr "Zuerst Nachnamen abkürzen"
 msgid "An overview of an individual’s descendants."
 msgstr "Ein Überblick über die Nachkommen einer Person."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 msgid "Behavior"
 msgstr "Verhalten"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Nur Geburtsname"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Geburtsname mit Ehenamen in Klammern"
 
@@ -136,7 +136,7 @@ msgstr ""
 "Verhalten für Bäume nach, die Spitznamen im separaten GEDCOM NICK-Feld "
 "speichern."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Nur Ehenamen"
 
@@ -222,15 +222,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Abbrechen"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "Unten"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "Links"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "Rechts"
 
@@ -238,7 +238,7 @@ msgstr "Rechts"
 msgid "save"
 msgstr "Speichern"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "Oben"
 

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Zuerst Vornamen abkürzen"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Zuerst Nachnamen abkürzen"
 
@@ -32,7 +32,7 @@ msgstr "Zuerst Nachnamen abkürzen"
 msgid "An overview of an individual’s descendants."
 msgstr "Ein Überblick über die Nachkommen einer Person."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 msgid "Behavior"
 msgstr "Verhalten"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Nur Geburtsname"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Geburtsname mit Ehenamen in Klammern"
 
@@ -136,7 +136,7 @@ msgstr ""
 "Verhalten für Bäume nach, die Spitznamen im separaten GEDCOM NICK-Feld "
 "speichern."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Nur Ehenamen"
 
@@ -222,15 +222,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Abbrechen"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "Unten"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "Links"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "Rechts"
 
@@ -238,7 +238,7 @@ msgstr "Rechts"
 msgid "save"
 msgstr "Speichern"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "Oben"
 

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Zuerst Vornamen abkürzen"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Zuerst Nachnamen abkürzen"
 
@@ -32,7 +32,7 @@ msgstr "Zuerst Nachnamen abkürzen"
 msgid "An overview of an individual’s descendants."
 msgstr "Ein Überblick über die Nachkommen einer Person."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 msgid "Behavior"
 msgstr "Verhalten"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Nur Geburtsname"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Geburtsname mit Ehenamen in Klammern"
 
@@ -136,7 +136,7 @@ msgstr ""
 "Verhalten für Bäume nach, die Spitznamen im separaten GEDCOM NICK-Feld "
 "speichern."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Nur Ehenamen"
 

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Abbreviate given names first"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Abbreviate surnames first"
 
@@ -32,7 +32,7 @@ msgstr "Abbreviate surnames first"
 msgid "An overview of an individual’s descendants."
 msgstr "An overview of an individual’s descendants."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatic (based on tree's surname tradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatic (based on tree's surname tradition)"
 msgid "Behavior"
 msgstr "Behavior"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Birth name only"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Birth name with married name in brackets"
 
@@ -132,7 +132,7 @@ msgstr ""
 "surname (e.g. Martin \"Chalky\" White). Mirrors the legacy webtrees "
 "behaviour for trees that store nicknames in the separate GEDCOM NICK field."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Married name only"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "cancel"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "down"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "left"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "right"
 
@@ -231,7 +231,7 @@ msgstr "right"
 msgid "save"
 msgstr "save"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "up"
 

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Abbreviate given names first"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Abbreviate surnames first"
 
@@ -32,7 +32,7 @@ msgstr "Abbreviate surnames first"
 msgid "An overview of an individual’s descendants."
 msgstr "An overview of an individual’s descendants."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatic (based on tree's surname tradition)"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "cancel"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "down"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "left"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "right"
 
@@ -231,7 +231,7 @@ msgstr "right"
 msgid "save"
 msgstr "save"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "up"
 

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Abbreviate given names first"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Abbreviate surnames first"
 
@@ -32,7 +32,7 @@ msgstr "Abbreviate surnames first"
 msgid "An overview of an individual’s descendants."
 msgstr "An overview of an individual’s descendants."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatic (based on tree's surname tradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatic (based on tree's surname tradition)"
 msgid "Behavior"
 msgstr "Behavior"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Birth name only"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Birth name with married name in brackets"
 
@@ -132,7 +132,7 @@ msgstr ""
 "surname (e.g. Martin \"Chalky\" White). Mirrors the legacy webtrees "
 "behaviour for trees that store nicknames in the separate GEDCOM NICK field."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Married name only"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "cancel"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "down"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "left"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "right"
 
@@ -231,7 +231,7 @@ msgstr "right"
 msgid "save"
 msgstr "save"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "up"
 

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Abbreviate given names first"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Abbreviate surnames first"
 
@@ -32,7 +32,7 @@ msgstr "Abbreviate surnames first"
 msgid "An overview of an individual’s descendants."
 msgstr "An overview of an individual’s descendants."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatic (based on tree's surname tradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatic (based on tree's surname tradition)"
 msgid "Behavior"
 msgstr "Behavior"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Birth name only"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Birth name with married name in brackets"
 
@@ -132,7 +132,7 @@ msgstr ""
 "surname (e.g. Martin \"Chalky\" White). Mirrors the legacy webtrees "
 "behaviour for trees that store nicknames in the separate GEDCOM NICK field."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Married name only"
 

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Abbreviate given names first"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Abbreviate surnames first"
 
@@ -32,7 +32,7 @@ msgstr "Abbreviate surnames first"
 msgid "An overview of an individual’s descendants."
 msgstr "An overview of an individual’s descendants."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatic (based on tree's surname tradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatic (based on tree's surname tradition)"
 msgid "Behavior"
 msgstr "Behavior"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Birth name only"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Birth name with married name in brackets"
 
@@ -132,7 +132,7 @@ msgstr ""
 "surname (e.g. Martin \"Chalky\" White). Mirrors the legacy webtrees "
 "behaviour for trees that store nicknames in the separate GEDCOM NICK field."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Married name only"
 

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Abbreviate given names first"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Abbreviate surnames first"
 
@@ -32,7 +32,7 @@ msgstr "Abbreviate surnames first"
 msgid "An overview of an individual’s descendants."
 msgstr "An overview of an individual’s descendants."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatic (based on tree's surname tradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatic (based on tree's surname tradition)"
 msgid "Behavior"
 msgstr "Behavior"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Birth name only"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Birth name with married name in brackets"
 
@@ -132,7 +132,7 @@ msgstr ""
 "surname (e.g. Martin \"Chalky\" White). Mirrors the legacy webtrees "
 "behaviour for trees that store nicknames in the separate GEDCOM NICK field."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Married name only"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "cancel"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "down"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "left"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "right"
 
@@ -231,7 +231,7 @@ msgstr "right"
 msgid "save"
 msgstr "save"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "up"
 

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Abbreviate given names first"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Abbreviate surnames first"
 
@@ -32,7 +32,7 @@ msgstr "Abbreviate surnames first"
 msgid "An overview of an individual’s descendants."
 msgstr "An overview of an individual’s descendants."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatic (based on tree's surname tradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatic (based on tree's surname tradition)"
 msgid "Behavior"
 msgstr "Behavior"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Birth name only"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Birth name with married name in brackets"
 
@@ -132,7 +132,7 @@ msgstr ""
 "surname (e.g. Martin \"Chalky\" White). Mirrors the legacy webtrees "
 "behaviour for trees that store nicknames in the separate GEDCOM NICK field."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Married name only"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "cancel"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "down"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "left"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "right"
 
@@ -231,7 +231,7 @@ msgstr "right"
 msgid "save"
 msgstr "save"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "up"
 

--- a/resources/lang/es/messages.po
+++ b/resources/lang/es/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Abreviar primero los nombres de pila"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Abreviar primero los apellidos"
 
@@ -32,7 +32,7 @@ msgstr "Abreviar primero los apellidos"
 msgid "An overview of an individual’s descendants."
 msgstr "Vista individual de descendientes."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automático (según la tradición de apellidos del árbol)"
 
@@ -218,15 +218,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Cancelar"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "abajo"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "izquierda"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "derecha"
 
@@ -234,7 +234,7 @@ msgstr "derecha"
 msgid "save"
 msgstr "guardar"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "arriba"
 

--- a/resources/lang/es/messages.po
+++ b/resources/lang/es/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Abreviar primero los nombres de pila"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Abreviar primero los apellidos"
 
@@ -32,7 +32,7 @@ msgstr "Abreviar primero los apellidos"
 msgid "An overview of an individual’s descendants."
 msgstr "Vista individual de descendientes."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automático (según la tradición de apellidos del árbol)"
 
@@ -40,11 +40,11 @@ msgstr "Automático (según la tradición de apellidos del árbol)"
 msgid "Behavior"
 msgstr "Comportamiento"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Solo nombre de nacimiento"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Nombre de nacimiento con nombre de casada entre paréntesis"
 
@@ -134,7 +134,7 @@ msgstr ""
 "webtrees para árboles que guardan los apodos en el campo GEDCOM NICK "
 "separado."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Solo nombre de casada"
 
@@ -218,15 +218,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Cancelar"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "abajo"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "izquierda"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "derecha"
 
@@ -234,7 +234,7 @@ msgstr "derecha"
 msgid "save"
 msgstr "guardar"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "arriba"
 

--- a/resources/lang/es/messages.po
+++ b/resources/lang/es/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Abreviar primero los nombres de pila"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Abreviar primero los apellidos"
 
@@ -32,7 +32,7 @@ msgstr "Abreviar primero los apellidos"
 msgid "An overview of an individual’s descendants."
 msgstr "Vista individual de descendientes."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automático (según la tradición de apellidos del árbol)"
 
@@ -40,11 +40,11 @@ msgstr "Automático (según la tradición de apellidos del árbol)"
 msgid "Behavior"
 msgstr "Comportamiento"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Solo nombre de nacimiento"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Nombre de nacimiento con nombre de casada entre paréntesis"
 
@@ -134,7 +134,7 @@ msgstr ""
 "webtrees para árboles que guardan los apodos en el campo GEDCOM NICK "
 "separado."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Solo nombre de casada"
 
@@ -218,15 +218,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Cancelar"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "abajo"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "izquierda"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "derecha"
 
@@ -234,7 +234,7 @@ msgstr "derecha"
 msgid "save"
 msgstr "guardar"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "arriba"
 

--- a/resources/lang/es/messages.po
+++ b/resources/lang/es/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Abreviar primero los nombres de pila"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Abreviar primero los apellidos"
 
@@ -32,7 +32,7 @@ msgstr "Abreviar primero los apellidos"
 msgid "An overview of an individual’s descendants."
 msgstr "Vista individual de descendientes."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automático (según la tradición de apellidos del árbol)"
 
@@ -40,11 +40,11 @@ msgstr "Automático (según la tradición de apellidos del árbol)"
 msgid "Behavior"
 msgstr "Comportamiento"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Solo nombre de nacimiento"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Nombre de nacimiento con nombre de casada entre paréntesis"
 
@@ -134,7 +134,7 @@ msgstr ""
 "webtrees para árboles que guardan los apodos en el campo GEDCOM NICK "
 "separado."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Solo nombre de casada"
 

--- a/resources/lang/es/messages.po
+++ b/resources/lang/es/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Abreviar primero los nombres de pila"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Abreviar primero los apellidos"
 
@@ -32,7 +32,7 @@ msgstr "Abreviar primero los apellidos"
 msgid "An overview of an individual’s descendants."
 msgstr "Vista individual de descendientes."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automático (según la tradición de apellidos del árbol)"
 
@@ -40,11 +40,11 @@ msgstr "Automático (según la tradición de apellidos del árbol)"
 msgid "Behavior"
 msgstr "Comportamiento"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Solo nombre de nacimiento"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Nombre de nacimiento con nombre de casada entre paréntesis"
 
@@ -134,7 +134,7 @@ msgstr ""
 "webtrees para árboles que guardan los apodos en el campo GEDCOM NICK "
 "separado."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Solo nombre de casada"
 
@@ -218,15 +218,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Cancelar"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "abajo"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "izquierda"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "derecha"
 
@@ -234,7 +234,7 @@ msgstr "derecha"
 msgid "save"
 msgstr "guardar"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "arriba"
 

--- a/resources/lang/es/messages.po
+++ b/resources/lang/es/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Abreviar primero los nombres de pila"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Abreviar primero los apellidos"
 
@@ -32,7 +32,7 @@ msgstr "Abreviar primero los apellidos"
 msgid "An overview of an individual’s descendants."
 msgstr "Vista individual de descendientes."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automático (según la tradición de apellidos del árbol)"
 
@@ -40,11 +40,11 @@ msgstr "Automático (según la tradición de apellidos del árbol)"
 msgid "Behavior"
 msgstr "Comportamiento"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Solo nombre de nacimiento"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Nombre de nacimiento con nombre de casada entre paréntesis"
 
@@ -134,7 +134,7 @@ msgstr ""
 "webtrees para árboles que guardan los apodos en el campo GEDCOM NICK "
 "separado."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Solo nombre de casada"
 

--- a/resources/lang/es/messages.po
+++ b/resources/lang/es/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Abreviar primero los nombres de pila"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Abreviar primero los apellidos"
 
@@ -32,7 +32,7 @@ msgstr "Abreviar primero los apellidos"
 msgid "An overview of an individual’s descendants."
 msgstr "Vista individual de descendientes."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automático (según la tradición de apellidos del árbol)"
 
@@ -40,11 +40,11 @@ msgstr "Automático (según la tradición de apellidos del árbol)"
 msgid "Behavior"
 msgstr "Comportamiento"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Solo nombre de nacimiento"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Nombre de nacimiento con nombre de casada entre paréntesis"
 
@@ -134,7 +134,7 @@ msgstr ""
 "webtrees para árboles que guardan los apodos en el campo GEDCOM NICK "
 "separado."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Solo nombre de casada"
 
@@ -218,15 +218,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Cancelar"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "abajo"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "izquierda"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "derecha"
 
@@ -234,7 +234,7 @@ msgstr "derecha"
 msgid "save"
 msgstr "guardar"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "arriba"
 

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Abréger d'abord les prénoms"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Abréger d'abord les noms de famille"
 
@@ -32,7 +32,7 @@ msgstr "Abréger d'abord les noms de famille"
 msgid "An overview of an individual’s descendants."
 msgstr "Un aperçu des descendants d’un individu."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 
@@ -40,11 +40,11 @@ msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 msgid "Behavior"
 msgstr "Comportement"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Nom de naissance uniquement"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Nom de naissance avec nom d'épouse entre parenthèses"
 
@@ -134,7 +134,7 @@ msgstr ""
 "de webtrees pour les arbres qui stockent les surnoms dans le champ GEDCOM "
 "NICK séparé."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Nom d'épouse uniquement"
 

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Abréger d'abord les prénoms"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Abréger d'abord les noms de famille"
 
@@ -32,7 +32,7 @@ msgstr "Abréger d'abord les noms de famille"
 msgid "An overview of an individual’s descendants."
 msgstr "Un aperçu des descendants d’un individu."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 
@@ -40,11 +40,11 @@ msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 msgid "Behavior"
 msgstr "Comportement"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Nom de naissance uniquement"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Nom de naissance avec nom d'épouse entre parenthèses"
 
@@ -134,7 +134,7 @@ msgstr ""
 "de webtrees pour les arbres qui stockent les surnoms dans le champ GEDCOM "
 "NICK séparé."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Nom d'épouse uniquement"
 
@@ -218,15 +218,15 @@ msgstr ""
 msgid "cancel"
 msgstr "annuler"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "bas"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "gauche"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "droite"
 
@@ -234,7 +234,7 @@ msgstr "droite"
 msgid "save"
 msgstr "enregistrer"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "haut"
 

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Abréger d'abord les prénoms"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Abréger d'abord les noms de famille"
 
@@ -32,7 +32,7 @@ msgstr "Abréger d'abord les noms de famille"
 msgid "An overview of an individual’s descendants."
 msgstr "Un aperçu des descendants d’un individu."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 
@@ -40,11 +40,11 @@ msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 msgid "Behavior"
 msgstr "Comportement"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Nom de naissance uniquement"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Nom de naissance avec nom d'épouse entre parenthèses"
 
@@ -134,7 +134,7 @@ msgstr ""
 "de webtrees pour les arbres qui stockent les surnoms dans le champ GEDCOM "
 "NICK séparé."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Nom d'épouse uniquement"
 
@@ -218,15 +218,15 @@ msgstr ""
 msgid "cancel"
 msgstr "annuler"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "bas"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "gauche"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "droite"
 
@@ -234,7 +234,7 @@ msgstr "droite"
 msgid "save"
 msgstr "enregistrer"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "haut"
 

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Abréger d'abord les prénoms"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Abréger d'abord les noms de famille"
 
@@ -32,7 +32,7 @@ msgstr "Abréger d'abord les noms de famille"
 msgid "An overview of an individual’s descendants."
 msgstr "Un aperçu des descendants d’un individu."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 
@@ -40,11 +40,11 @@ msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 msgid "Behavior"
 msgstr "Comportement"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Nom de naissance uniquement"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Nom de naissance avec nom d'épouse entre parenthèses"
 
@@ -134,7 +134,7 @@ msgstr ""
 "de webtrees pour les arbres qui stockent les surnoms dans le champ GEDCOM "
 "NICK séparé."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Nom d'épouse uniquement"
 
@@ -218,15 +218,15 @@ msgstr ""
 msgid "cancel"
 msgstr "annuler"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "bas"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "gauche"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "droite"
 
@@ -234,7 +234,7 @@ msgstr "droite"
 msgid "save"
 msgstr "enregistrer"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "haut"
 

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Abréger d'abord les prénoms"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Abréger d'abord les noms de famille"
 
@@ -32,7 +32,7 @@ msgstr "Abréger d'abord les noms de famille"
 msgid "An overview of an individual’s descendants."
 msgstr "Un aperçu des descendants d’un individu."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 
@@ -40,11 +40,11 @@ msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 msgid "Behavior"
 msgstr "Comportement"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Nom de naissance uniquement"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Nom de naissance avec nom d'épouse entre parenthèses"
 
@@ -134,7 +134,7 @@ msgstr ""
 "de webtrees pour les arbres qui stockent les surnoms dans le champ GEDCOM "
 "NICK séparé."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Nom d'épouse uniquement"
 
@@ -218,15 +218,15 @@ msgstr ""
 msgid "cancel"
 msgstr "annuler"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "bas"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "gauche"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "droite"
 
@@ -234,7 +234,7 @@ msgstr "droite"
 msgid "save"
 msgstr "enregistrer"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "haut"
 

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Abréger d'abord les prénoms"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Abréger d'abord les noms de famille"
 
@@ -32,7 +32,7 @@ msgstr "Abréger d'abord les noms de famille"
 msgid "An overview of an individual’s descendants."
 msgstr "Un aperçu des descendants d’un individu."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 
@@ -218,15 +218,15 @@ msgstr ""
 msgid "cancel"
 msgstr "annuler"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "bas"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "gauche"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "droite"
 
@@ -234,7 +234,7 @@ msgstr "droite"
 msgid "save"
 msgstr "enregistrer"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "haut"
 

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Abréger d'abord les prénoms"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Abréger d'abord les noms de famille"
 
@@ -32,7 +32,7 @@ msgstr "Abréger d'abord les noms de famille"
 msgid "An overview of an individual’s descendants."
 msgstr "Un aperçu des descendants d’un individu."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 
@@ -40,11 +40,11 @@ msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 msgid "Behavior"
 msgstr "Comportement"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Nom de naissance uniquement"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Nom de naissance avec nom d'épouse entre parenthèses"
 
@@ -134,7 +134,7 @@ msgstr ""
 "de webtrees pour les arbres qui stockent les surnoms dans le champ GEDCOM "
 "NICK séparé."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Nom d'épouse uniquement"
 

--- a/resources/lang/is/messages.po
+++ b/resources/lang/is/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Stytta eiginnöfn fyrst"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Stytta eftirnöfn fyrst"
 
@@ -32,7 +32,7 @@ msgstr "Stytta eftirnöfn fyrst"
 msgid "An overview of an individual’s descendants."
 msgstr "Yfirlit yfir afkomendur einstaklings."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 
@@ -40,11 +40,11 @@ msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 msgid "Behavior"
 msgstr "Hegðun"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Aðeins fæðingarnafn"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Fæðingarnafn með giftingarnafni innan sviga"
 
@@ -134,7 +134,7 @@ msgstr ""
 "(t.d. Martin \"Chalky\" White). Líkir eftir gamla webtrees-hegðuninni fyrir "
 "tré sem geyma gælunöfn í sérstaka GEDCOM NICK-reitinn."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Aðeins giftingarnafn"
 

--- a/resources/lang/is/messages.po
+++ b/resources/lang/is/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Stytta eiginnöfn fyrst"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Stytta eftirnöfn fyrst"
 
@@ -32,7 +32,7 @@ msgstr "Stytta eftirnöfn fyrst"
 msgid "An overview of an individual’s descendants."
 msgstr "Yfirlit yfir afkomendur einstaklings."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 
@@ -40,11 +40,11 @@ msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 msgid "Behavior"
 msgstr "Hegðun"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Aðeins fæðingarnafn"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Fæðingarnafn með giftingarnafni innan sviga"
 
@@ -134,7 +134,7 @@ msgstr ""
 "(t.d. Martin \"Chalky\" White). Líkir eftir gamla webtrees-hegðuninni fyrir "
 "tré sem geyma gælunöfn í sérstaka GEDCOM NICK-reitinn."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Aðeins giftingarnafn"
 

--- a/resources/lang/is/messages.po
+++ b/resources/lang/is/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Stytta eiginnöfn fyrst"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Stytta eftirnöfn fyrst"
 
@@ -32,7 +32,7 @@ msgstr "Stytta eftirnöfn fyrst"
 msgid "An overview of an individual’s descendants."
 msgstr "Yfirlit yfir afkomendur einstaklings."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 
@@ -40,11 +40,11 @@ msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 msgid "Behavior"
 msgstr "Hegðun"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Aðeins fæðingarnafn"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Fæðingarnafn með giftingarnafni innan sviga"
 
@@ -134,7 +134,7 @@ msgstr ""
 "(t.d. Martin \"Chalky\" White). Líkir eftir gamla webtrees-hegðuninni fyrir "
 "tré sem geyma gælunöfn í sérstaka GEDCOM NICK-reitinn."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Aðeins giftingarnafn"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "hætta"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "niður"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "vinstri"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "hægri"
 
@@ -235,7 +235,7 @@ msgstr "hægri"
 msgid "save"
 msgstr "vista"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "upp"
 

--- a/resources/lang/is/messages.po
+++ b/resources/lang/is/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Stytta eiginnöfn fyrst"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Stytta eftirnöfn fyrst"
 
@@ -32,7 +32,7 @@ msgstr "Stytta eftirnöfn fyrst"
 msgid "An overview of an individual’s descendants."
 msgstr "Yfirlit yfir afkomendur einstaklings."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 
@@ -40,11 +40,11 @@ msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 msgid "Behavior"
 msgstr "Hegðun"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Aðeins fæðingarnafn"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Fæðingarnafn með giftingarnafni innan sviga"
 
@@ -134,7 +134,7 @@ msgstr ""
 "(t.d. Martin \"Chalky\" White). Líkir eftir gamla webtrees-hegðuninni fyrir "
 "tré sem geyma gælunöfn í sérstaka GEDCOM NICK-reitinn."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Aðeins giftingarnafn"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "hætta"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "niður"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "vinstri"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "hægri"
 
@@ -235,7 +235,7 @@ msgstr "hægri"
 msgid "save"
 msgstr "vista"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "upp"
 

--- a/resources/lang/is/messages.po
+++ b/resources/lang/is/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Stytta eiginnöfn fyrst"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Stytta eftirnöfn fyrst"
 
@@ -32,7 +32,7 @@ msgstr "Stytta eftirnöfn fyrst"
 msgid "An overview of an individual’s descendants."
 msgstr "Yfirlit yfir afkomendur einstaklings."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "hætta"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "niður"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "vinstri"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "hægri"
 
@@ -235,7 +235,7 @@ msgstr "hægri"
 msgid "save"
 msgstr "vista"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "upp"
 

--- a/resources/lang/is/messages.po
+++ b/resources/lang/is/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Stytta eiginnöfn fyrst"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Stytta eftirnöfn fyrst"
 
@@ -32,7 +32,7 @@ msgstr "Stytta eftirnöfn fyrst"
 msgid "An overview of an individual’s descendants."
 msgstr "Yfirlit yfir afkomendur einstaklings."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 
@@ -40,11 +40,11 @@ msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 msgid "Behavior"
 msgstr "Hegðun"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Aðeins fæðingarnafn"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Fæðingarnafn með giftingarnafni innan sviga"
 
@@ -134,7 +134,7 @@ msgstr ""
 "(t.d. Martin \"Chalky\" White). Líkir eftir gamla webtrees-hegðuninni fyrir "
 "tré sem geyma gælunöfn í sérstaka GEDCOM NICK-reitinn."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Aðeins giftingarnafn"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "hætta"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "niður"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "vinstri"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "hægri"
 
@@ -235,7 +235,7 @@ msgstr "hægri"
 msgid "save"
 msgstr "vista"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "upp"
 

--- a/resources/lang/is/messages.po
+++ b/resources/lang/is/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Stytta eiginnöfn fyrst"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Stytta eftirnöfn fyrst"
 
@@ -32,7 +32,7 @@ msgstr "Stytta eftirnöfn fyrst"
 msgid "An overview of an individual’s descendants."
 msgstr "Yfirlit yfir afkomendur einstaklings."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 
@@ -40,11 +40,11 @@ msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 msgid "Behavior"
 msgstr "Hegðun"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Aðeins fæðingarnafn"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Fæðingarnafn með giftingarnafni innan sviga"
 
@@ -134,7 +134,7 @@ msgstr ""
 "(t.d. Martin \"Chalky\" White). Líkir eftir gamla webtrees-hegðuninni fyrir "
 "tré sem geyma gælunöfn í sérstaka GEDCOM NICK-reitinn."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Aðeins giftingarnafn"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "hætta"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "niður"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "vinstri"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "hægri"
 
@@ -235,7 +235,7 @@ msgstr "hægri"
 msgid "save"
 msgstr "vista"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "upp"
 

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavn først"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternavn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternavn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Et diagram over en persons etterkommere."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på treets etternavnstradisjon)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (basert på treets etternavnstradisjon)"
 msgid "Behavior"
 msgstr "Atferd"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Bare fødselsnavn"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Fødselsnavn med navn som gift i parentes"
 
@@ -134,7 +134,7 @@ msgstr ""
 "(f.eks. Martin \"Chalky\" White). Gjenskaper den tidligere webtrees-"
 "oppførselen for trær som lagrer kallenavn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Bare navn som gift"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "høyre"
 
@@ -235,7 +235,7 @@ msgstr "høyre"
 msgid "save"
 msgstr "lagre"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "opp"
 

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavn først"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternavn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternavn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Et diagram over en persons etterkommere."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på treets etternavnstradisjon)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (basert på treets etternavnstradisjon)"
 msgid "Behavior"
 msgstr "Atferd"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Bare fødselsnavn"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Fødselsnavn med navn som gift i parentes"
 
@@ -134,7 +134,7 @@ msgstr ""
 "(f.eks. Martin \"Chalky\" White). Gjenskaper den tidligere webtrees-"
 "oppførselen for trær som lagrer kallenavn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Bare navn som gift"
 

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavn først"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternavn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternavn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Et diagram over en persons etterkommere."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på treets etternavnstradisjon)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (basert på treets etternavnstradisjon)"
 msgid "Behavior"
 msgstr "Atferd"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Bare fødselsnavn"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Fødselsnavn med navn som gift i parentes"
 
@@ -134,7 +134,7 @@ msgstr ""
 "(f.eks. Martin \"Chalky\" White). Gjenskaper den tidligere webtrees-"
 "oppførselen for trær som lagrer kallenavn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Bare navn som gift"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "høyre"
 
@@ -235,7 +235,7 @@ msgstr "høyre"
 msgid "save"
 msgstr "lagre"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "opp"
 

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavn først"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternavn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternavn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Et diagram over en persons etterkommere."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på treets etternavnstradisjon)"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "høyre"
 
@@ -235,7 +235,7 @@ msgstr "høyre"
 msgid "save"
 msgstr "lagre"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "opp"
 

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavn først"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternavn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternavn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Et diagram over en persons etterkommere."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på treets etternavnstradisjon)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (basert på treets etternavnstradisjon)"
 msgid "Behavior"
 msgstr "Atferd"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Bare fødselsnavn"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Fødselsnavn med navn som gift i parentes"
 
@@ -134,7 +134,7 @@ msgstr ""
 "(f.eks. Martin \"Chalky\" White). Gjenskaper den tidligere webtrees-"
 "oppførselen for trær som lagrer kallenavn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Bare navn som gift"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "høyre"
 
@@ -235,7 +235,7 @@ msgstr "høyre"
 msgid "save"
 msgstr "lagre"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "opp"
 

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavn først"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternavn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternavn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Et diagram over en persons etterkommere."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på treets etternavnstradisjon)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (basert på treets etternavnstradisjon)"
 msgid "Behavior"
 msgstr "Atferd"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Bare fødselsnavn"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Fødselsnavn med navn som gift i parentes"
 
@@ -134,7 +134,7 @@ msgstr ""
 "(f.eks. Martin \"Chalky\" White). Gjenskaper den tidligere webtrees-"
 "oppførselen for trær som lagrer kallenavn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Bare navn som gift"
 

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavn først"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternavn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternavn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Et diagram over en persons etterkommere."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på treets etternavnstradisjon)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (basert på treets etternavnstradisjon)"
 msgid "Behavior"
 msgstr "Atferd"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Bare fødselsnavn"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Fødselsnavn med navn som gift i parentes"
 
@@ -134,7 +134,7 @@ msgstr ""
 "(f.eks. Martin \"Chalky\" White). Gjenskaper den tidligere webtrees-"
 "oppførselen for trær som lagrer kallenavn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Bare navn som gift"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "høyre"
 
@@ -235,7 +235,7 @@ msgstr "høyre"
 msgid "save"
 msgstr "lagre"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "opp"
 

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Voornamen eerst afkorten"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Achternamen eerst afkorten"
 
@@ -32,7 +32,7 @@ msgstr "Achternamen eerst afkorten"
 msgid "An overview of an individual’s descendants."
 msgstr "Een overzicht van de afstammelingen van een persoon."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 msgid "Behavior"
 msgstr "Gedrag"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Alleen geboortenaam"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Geboortenaam met huwelijksnaam tussen haakjes"
 
@@ -136,7 +136,7 @@ msgstr ""
 "gedrag na voor stambomen die bijnamen in het afzonderlijke GEDCOM NICK-veld "
 "opslaan."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Alleen huwelijksnaam"
 
@@ -220,15 +220,15 @@ msgstr ""
 msgid "cancel"
 msgstr "annuleren"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "omlaag"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "links"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "rechts"
 
@@ -236,7 +236,7 @@ msgstr "rechts"
 msgid "save"
 msgstr "opslaan"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "omhoog"
 

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Voornamen eerst afkorten"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Achternamen eerst afkorten"
 
@@ -32,7 +32,7 @@ msgstr "Achternamen eerst afkorten"
 msgid "An overview of an individual’s descendants."
 msgstr "Een overzicht van de afstammelingen van een persoon."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 msgid "Behavior"
 msgstr "Gedrag"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Alleen geboortenaam"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Geboortenaam met huwelijksnaam tussen haakjes"
 
@@ -136,7 +136,7 @@ msgstr ""
 "gedrag na voor stambomen die bijnamen in het afzonderlijke GEDCOM NICK-veld "
 "opslaan."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Alleen huwelijksnaam"
 
@@ -220,15 +220,15 @@ msgstr ""
 msgid "cancel"
 msgstr "annuleren"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "omlaag"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "links"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "rechts"
 
@@ -236,7 +236,7 @@ msgstr "rechts"
 msgid "save"
 msgstr "opslaan"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "omhoog"
 

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Voornamen eerst afkorten"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Achternamen eerst afkorten"
 
@@ -32,7 +32,7 @@ msgstr "Achternamen eerst afkorten"
 msgid "An overview of an individual’s descendants."
 msgstr "Een overzicht van de afstammelingen van een persoon."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 msgid "Behavior"
 msgstr "Gedrag"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Alleen geboortenaam"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Geboortenaam met huwelijksnaam tussen haakjes"
 
@@ -136,7 +136,7 @@ msgstr ""
 "gedrag na voor stambomen die bijnamen in het afzonderlijke GEDCOM NICK-veld "
 "opslaan."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Alleen huwelijksnaam"
 
@@ -220,15 +220,15 @@ msgstr ""
 msgid "cancel"
 msgstr "annuleren"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "omlaag"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "links"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "rechts"
 
@@ -236,7 +236,7 @@ msgstr "rechts"
 msgid "save"
 msgstr "opslaan"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "omhoog"
 

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Voornamen eerst afkorten"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Achternamen eerst afkorten"
 
@@ -32,7 +32,7 @@ msgstr "Achternamen eerst afkorten"
 msgid "An overview of an individual’s descendants."
 msgstr "Een overzicht van de afstammelingen van een persoon."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 msgid "Behavior"
 msgstr "Gedrag"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Alleen geboortenaam"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Geboortenaam met huwelijksnaam tussen haakjes"
 
@@ -136,7 +136,7 @@ msgstr ""
 "gedrag na voor stambomen die bijnamen in het afzonderlijke GEDCOM NICK-veld "
 "opslaan."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Alleen huwelijksnaam"
 

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Voornamen eerst afkorten"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Achternamen eerst afkorten"
 
@@ -32,7 +32,7 @@ msgstr "Achternamen eerst afkorten"
 msgid "An overview of an individual’s descendants."
 msgstr "Een overzicht van de afstammelingen van een persoon."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 msgid "Behavior"
 msgstr "Gedrag"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Alleen geboortenaam"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Geboortenaam met huwelijksnaam tussen haakjes"
 
@@ -136,7 +136,7 @@ msgstr ""
 "gedrag na voor stambomen die bijnamen in het afzonderlijke GEDCOM NICK-veld "
 "opslaan."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Alleen huwelijksnaam"
 

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Voornamen eerst afkorten"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Achternamen eerst afkorten"
 
@@ -32,7 +32,7 @@ msgstr "Achternamen eerst afkorten"
 msgid "An overview of an individual’s descendants."
 msgstr "Een overzicht van de afstammelingen van een persoon."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 msgid "Behavior"
 msgstr "Gedrag"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Alleen geboortenaam"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Geboortenaam met huwelijksnaam tussen haakjes"
 
@@ -136,7 +136,7 @@ msgstr ""
 "gedrag na voor stambomen die bijnamen in het afzonderlijke GEDCOM NICK-veld "
 "opslaan."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Alleen huwelijksnaam"
 
@@ -220,15 +220,15 @@ msgstr ""
 msgid "cancel"
 msgstr "annuleren"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "omlaag"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "links"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "rechts"
 
@@ -236,7 +236,7 @@ msgstr "rechts"
 msgid "save"
 msgstr "opslaan"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "omhoog"
 

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Voornamen eerst afkorten"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Achternamen eerst afkorten"
 
@@ -32,7 +32,7 @@ msgstr "Achternamen eerst afkorten"
 msgid "An overview of an individual’s descendants."
 msgstr "Een overzicht van de afstammelingen van een persoon."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 
@@ -220,15 +220,15 @@ msgstr ""
 msgid "cancel"
 msgstr "annuleren"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "omlaag"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "links"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "rechts"
 
@@ -236,7 +236,7 @@ msgstr "rechts"
 msgid "save"
 msgstr "opslaan"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "omhoog"
 

--- a/resources/lang/nn/messages.po
+++ b/resources/lang/nn/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Forkort førenamn først"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternamn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternamn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Eit diagram som syner ein person sine etterkomarar."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 msgid "Behavior"
 msgstr "Åtferd"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Berre fødenamn"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Fødenamn med namn som gift i parentes"
 
@@ -134,7 +134,7 @@ msgstr ""
 "Martin \"Chalky\" White). Tek att den gamle webtrees-åtferda for tre som "
 "lagrar kallenamn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Berre namn som gift"
 

--- a/resources/lang/nn/messages.po
+++ b/resources/lang/nn/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Forkort førenamn først"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternamn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternamn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Eit diagram som syner ein person sine etterkomarar."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 msgid "Behavior"
 msgstr "Åtferd"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Berre fødenamn"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Fødenamn med namn som gift i parentes"
 
@@ -134,7 +134,7 @@ msgstr ""
 "Martin \"Chalky\" White). Tek att den gamle webtrees-åtferda for tre som "
 "lagrar kallenamn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Berre namn som gift"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "høgre"
 
@@ -235,7 +235,7 @@ msgstr "høgre"
 msgid "save"
 msgstr "lagre"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "opp"
 

--- a/resources/lang/nn/messages.po
+++ b/resources/lang/nn/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Forkort førenamn først"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternamn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternamn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Eit diagram som syner ein person sine etterkomarar."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 msgid "Behavior"
 msgstr "Åtferd"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Berre fødenamn"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Fødenamn med namn som gift i parentes"
 
@@ -134,7 +134,7 @@ msgstr ""
 "Martin \"Chalky\" White). Tek att den gamle webtrees-åtferda for tre som "
 "lagrar kallenamn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Berre namn som gift"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "høgre"
 
@@ -235,7 +235,7 @@ msgstr "høgre"
 msgid "save"
 msgstr "lagre"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "opp"
 

--- a/resources/lang/nn/messages.po
+++ b/resources/lang/nn/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Forkort førenamn først"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternamn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternamn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Eit diagram som syner ein person sine etterkomarar."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 msgid "Behavior"
 msgstr "Åtferd"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Berre fødenamn"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Fødenamn med namn som gift i parentes"
 
@@ -134,7 +134,7 @@ msgstr ""
 "Martin \"Chalky\" White). Tek att den gamle webtrees-åtferda for tre som "
 "lagrar kallenamn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Berre namn som gift"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "høgre"
 
@@ -235,7 +235,7 @@ msgstr "høgre"
 msgid "save"
 msgstr "lagre"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "opp"
 

--- a/resources/lang/nn/messages.po
+++ b/resources/lang/nn/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Forkort førenamn først"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternamn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternamn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Eit diagram som syner ein person sine etterkomarar."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 msgid "Behavior"
 msgstr "Åtferd"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Berre fødenamn"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Fødenamn med namn som gift i parentes"
 
@@ -134,7 +134,7 @@ msgstr ""
 "Martin \"Chalky\" White). Tek att den gamle webtrees-åtferda for tre som "
 "lagrar kallenamn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Berre namn som gift"
 

--- a/resources/lang/nn/messages.po
+++ b/resources/lang/nn/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Forkort førenamn først"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternamn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternamn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Eit diagram som syner ein person sine etterkomarar."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 msgid "Behavior"
 msgstr "Åtferd"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Berre fødenamn"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Fødenamn med namn som gift i parentes"
 
@@ -134,7 +134,7 @@ msgstr ""
 "Martin \"Chalky\" White). Tek att den gamle webtrees-åtferda for tre som "
 "lagrar kallenamn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Berre namn som gift"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "høgre"
 
@@ -235,7 +235,7 @@ msgstr "høgre"
 msgid "save"
 msgstr "lagre"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "opp"
 

--- a/resources/lang/nn/messages.po
+++ b/resources/lang/nn/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Forkort førenamn først"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternamn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternamn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Eit diagram som syner ein person sine etterkomarar."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "høgre"
 
@@ -235,7 +235,7 @@ msgstr "høgre"
 msgid "save"
 msgstr "lagre"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "opp"
 

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Сокращать сначала имена"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Сокращать сначала фамилии"
 
@@ -32,7 +32,7 @@ msgstr "Сокращать сначала фамилии"
 msgid "An overview of an individual’s descendants."
 msgstr "Диаграмма потомков в виде дерева."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматически (по традиции фамилий дерева)"
 
@@ -40,11 +40,11 @@ msgstr "Автоматически (по традиции фамилий дер�
 msgid "Behavior"
 msgstr "Поведение"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Только имя при рождении"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Имя при рождении с фамилией в браке в скобках"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(например, Martin \"Chalky\" White). Повторяет прежнее поведение webtrees "
 "для деревьев, в которых прозвища хранятся в отдельном поле GEDCOM NICK."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Только фамилия в браке"
 

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Сокращать сначала имена"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Сокращать сначала фамилии"
 
@@ -32,7 +32,7 @@ msgstr "Сокращать сначала фамилии"
 msgid "An overview of an individual’s descendants."
 msgstr "Диаграмма потомков в виде дерева."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматически (по традиции фамилий дерева)"
 
@@ -40,11 +40,11 @@ msgstr "Автоматически (по традиции фамилий дер�
 msgid "Behavior"
 msgstr "Поведение"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Только имя при рождении"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Имя при рождении с фамилией в браке в скобках"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(например, Martin \"Chalky\" White). Повторяет прежнее поведение webtrees "
 "для деревьев, в которых прозвища хранятся в отдельном поле GEDCOM NICK."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Только фамилия в браке"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Отмена"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "вниз"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "влево"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "вправо"
 
@@ -231,7 +231,7 @@ msgstr "вправо"
 msgid "save"
 msgstr "Сохранить"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "вверх"
 

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Сокращать сначала имена"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Сокращать сначала фамилии"
 
@@ -32,7 +32,7 @@ msgstr "Сокращать сначала фамилии"
 msgid "An overview of an individual’s descendants."
 msgstr "Диаграмма потомков в виде дерева."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматически (по традиции фамилий дерева)"
 
@@ -40,11 +40,11 @@ msgstr "Автоматически (по традиции фамилий дер�
 msgid "Behavior"
 msgstr "Поведение"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Только имя при рождении"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Имя при рождении с фамилией в браке в скобках"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(например, Martin \"Chalky\" White). Повторяет прежнее поведение webtrees "
 "для деревьев, в которых прозвища хранятся в отдельном поле GEDCOM NICK."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Только фамилия в браке"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Отмена"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "вниз"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "влево"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "вправо"
 
@@ -231,7 +231,7 @@ msgstr "вправо"
 msgid "save"
 msgstr "Сохранить"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "вверх"
 

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Сокращать сначала имена"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Сокращать сначала фамилии"
 
@@ -32,7 +32,7 @@ msgstr "Сокращать сначала фамилии"
 msgid "An overview of an individual’s descendants."
 msgstr "Диаграмма потомков в виде дерева."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматически (по традиции фамилий дерева)"
 
@@ -40,11 +40,11 @@ msgstr "Автоматически (по традиции фамилий дер�
 msgid "Behavior"
 msgstr "Поведение"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Только имя при рождении"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Имя при рождении с фамилией в браке в скобках"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(например, Martin \"Chalky\" White). Повторяет прежнее поведение webtrees "
 "для деревьев, в которых прозвища хранятся в отдельном поле GEDCOM NICK."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Только фамилия в браке"
 

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Сокращать сначала имена"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Сокращать сначала фамилии"
 
@@ -32,7 +32,7 @@ msgstr "Сокращать сначала фамилии"
 msgid "An overview of an individual’s descendants."
 msgstr "Диаграмма потомков в виде дерева."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматически (по традиции фамилий дерева)"
 
@@ -40,11 +40,11 @@ msgstr "Автоматически (по традиции фамилий дер�
 msgid "Behavior"
 msgstr "Поведение"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Только имя при рождении"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Имя при рождении с фамилией в браке в скобках"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(например, Martin \"Chalky\" White). Повторяет прежнее поведение webtrees "
 "для деревьев, в которых прозвища хранятся в отдельном поле GEDCOM NICK."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Только фамилия в браке"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Отмена"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "вниз"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "влево"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "вправо"
 
@@ -231,7 +231,7 @@ msgstr "вправо"
 msgid "save"
 msgstr "Сохранить"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "вверх"
 

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Сокращать сначала имена"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Сокращать сначала фамилии"
 
@@ -32,7 +32,7 @@ msgstr "Сокращать сначала фамилии"
 msgid "An overview of an individual’s descendants."
 msgstr "Диаграмма потомков в виде дерева."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматически (по традиции фамилий дерева)"
 
@@ -40,11 +40,11 @@ msgstr "Автоматически (по традиции фамилий дер�
 msgid "Behavior"
 msgstr "Поведение"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Только имя при рождении"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Имя при рождении с фамилией в браке в скобках"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(например, Martin \"Chalky\" White). Повторяет прежнее поведение webtrees "
 "для деревьев, в которых прозвища хранятся в отдельном поле GEDCOM NICK."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Только фамилия в браке"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Отмена"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "вниз"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "влево"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "вправо"
 
@@ -231,7 +231,7 @@ msgstr "вправо"
 msgid "save"
 msgstr "Сохранить"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "вверх"
 

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Сокращать сначала имена"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Сокращать сначала фамилии"
 
@@ -32,7 +32,7 @@ msgstr "Сокращать сначала фамилии"
 msgid "An overview of an individual’s descendants."
 msgstr "Диаграмма потомков в виде дерева."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматически (по традиции фамилий дерева)"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Отмена"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "вниз"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "влево"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "вправо"
 
@@ -231,7 +231,7 @@ msgstr "вправо"
 msgid "save"
 msgstr "Сохранить"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "вверх"
 

--- a/resources/lang/sl/messages.po
+++ b/resources/lang/sl/messages.po
@@ -23,11 +23,11 @@ msgstr ""
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 "X-Loco-Parser: loco_parse_po\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Najprej skrajšaj osebna imena"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Najprej skrajšaj priimke"
 
@@ -35,7 +35,7 @@ msgstr "Najprej skrajšaj priimke"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomcev osebe."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 
@@ -222,15 +222,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Prekliči"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "Dol"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "Levo"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "Desno"
 
@@ -238,7 +238,7 @@ msgstr "Desno"
 msgid "save"
 msgstr "Shrani"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "Gor"
 

--- a/resources/lang/sl/messages.po
+++ b/resources/lang/sl/messages.po
@@ -23,11 +23,11 @@ msgstr ""
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 "X-Loco-Parser: loco_parse_po\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Najprej skrajšaj osebna imena"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Najprej skrajšaj priimke"
 
@@ -35,7 +35,7 @@ msgstr "Najprej skrajšaj priimke"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomcev osebe."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 
@@ -43,11 +43,11 @@ msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 msgid "Behavior"
 msgstr "Vedenje"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Samo rojstno ime"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Rojstno ime s poročnim priimkom v oklepaju"
 
@@ -137,7 +137,7 @@ msgstr ""
 "Martin \"Chalky\" White). Posnema staro vedenje webtrees za drevesa, ki "
 "vzdevke shranjujejo v ločenem polju GEDCOM NICK."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Samo poročni priimek"
 
@@ -222,15 +222,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Prekliči"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "Dol"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "Levo"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "Desno"
 
@@ -238,7 +238,7 @@ msgstr "Desno"
 msgid "save"
 msgstr "Shrani"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "Gor"
 

--- a/resources/lang/sl/messages.po
+++ b/resources/lang/sl/messages.po
@@ -23,11 +23,11 @@ msgstr ""
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 "X-Loco-Parser: loco_parse_po\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Najprej skrajšaj osebna imena"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Najprej skrajšaj priimke"
 
@@ -35,7 +35,7 @@ msgstr "Najprej skrajšaj priimke"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomcev osebe."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 
@@ -43,11 +43,11 @@ msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 msgid "Behavior"
 msgstr "Vedenje"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Samo rojstno ime"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Rojstno ime s poročnim priimkom v oklepaju"
 
@@ -137,7 +137,7 @@ msgstr ""
 "Martin \"Chalky\" White). Posnema staro vedenje webtrees za drevesa, ki "
 "vzdevke shranjujejo v ločenem polju GEDCOM NICK."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Samo poročni priimek"
 

--- a/resources/lang/sl/messages.po
+++ b/resources/lang/sl/messages.po
@@ -23,11 +23,11 @@ msgstr ""
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 "X-Loco-Parser: loco_parse_po\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Najprej skrajšaj osebna imena"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Najprej skrajšaj priimke"
 
@@ -35,7 +35,7 @@ msgstr "Najprej skrajšaj priimke"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomcev osebe."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 
@@ -43,11 +43,11 @@ msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 msgid "Behavior"
 msgstr "Vedenje"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Samo rojstno ime"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Rojstno ime s poročnim priimkom v oklepaju"
 
@@ -137,7 +137,7 @@ msgstr ""
 "Martin \"Chalky\" White). Posnema staro vedenje webtrees za drevesa, ki "
 "vzdevke shranjujejo v ločenem polju GEDCOM NICK."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Samo poročni priimek"
 
@@ -222,15 +222,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Prekliči"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "Dol"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "Levo"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "Desno"
 
@@ -238,7 +238,7 @@ msgstr "Desno"
 msgid "save"
 msgstr "Shrani"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "Gor"
 

--- a/resources/lang/sl/messages.po
+++ b/resources/lang/sl/messages.po
@@ -23,11 +23,11 @@ msgstr ""
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 "X-Loco-Parser: loco_parse_po\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Najprej skrajšaj osebna imena"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Najprej skrajšaj priimke"
 
@@ -35,7 +35,7 @@ msgstr "Najprej skrajšaj priimke"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomcev osebe."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 
@@ -43,11 +43,11 @@ msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 msgid "Behavior"
 msgstr "Vedenje"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Samo rojstno ime"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Rojstno ime s poročnim priimkom v oklepaju"
 
@@ -137,7 +137,7 @@ msgstr ""
 "Martin \"Chalky\" White). Posnema staro vedenje webtrees za drevesa, ki "
 "vzdevke shranjujejo v ločenem polju GEDCOM NICK."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Samo poročni priimek"
 

--- a/resources/lang/sl/messages.po
+++ b/resources/lang/sl/messages.po
@@ -23,11 +23,11 @@ msgstr ""
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 "X-Loco-Parser: loco_parse_po\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Najprej skrajšaj osebna imena"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Najprej skrajšaj priimke"
 
@@ -35,7 +35,7 @@ msgstr "Najprej skrajšaj priimke"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomcev osebe."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 
@@ -43,11 +43,11 @@ msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 msgid "Behavior"
 msgstr "Vedenje"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Samo rojstno ime"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Rojstno ime s poročnim priimkom v oklepaju"
 
@@ -137,7 +137,7 @@ msgstr ""
 "Martin \"Chalky\" White). Posnema staro vedenje webtrees za drevesa, ki "
 "vzdevke shranjujejo v ločenem polju GEDCOM NICK."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Samo poročni priimek"
 
@@ -222,15 +222,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Prekliči"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "Dol"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "Levo"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "Desno"
 
@@ -238,7 +238,7 @@ msgstr "Desno"
 msgid "save"
 msgstr "Shrani"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "Gor"
 

--- a/resources/lang/sl/messages.po
+++ b/resources/lang/sl/messages.po
@@ -23,11 +23,11 @@ msgstr ""
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 "X-Loco-Parser: loco_parse_po\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Najprej skrajšaj osebna imena"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Najprej skrajšaj priimke"
 
@@ -35,7 +35,7 @@ msgstr "Najprej skrajšaj priimke"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomcev osebe."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 
@@ -43,11 +43,11 @@ msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 msgid "Behavior"
 msgstr "Vedenje"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Samo rojstno ime"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Rojstno ime s poročnim priimkom v oklepaju"
 
@@ -137,7 +137,7 @@ msgstr ""
 "Martin \"Chalky\" White). Posnema staro vedenje webtrees za drevesa, ki "
 "vzdevke shranjujejo v ločenem polju GEDCOM NICK."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Samo poročni priimek"
 
@@ -222,15 +222,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Prekliči"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "Dol"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "Levo"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "Desno"
 
@@ -238,7 +238,7 @@ msgstr "Desno"
 msgid "save"
 msgstr "Shrani"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "Gor"
 

--- a/resources/lang/sr-Latn/messages.po
+++ b/resources/lang/sr-Latn/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Prvo skrati lična imena"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Prvo skrati prezimena"
 
@@ -33,7 +33,7 @@ msgstr "Prvo skrati prezimena"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomaka pojedinca."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 
@@ -41,11 +41,11 @@ msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 msgid "Behavior"
 msgstr "Ponašanje"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Samo rodno ime"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Rodno ime sa bračnim prezimenom u zagradi"
 
@@ -133,7 +133,7 @@ msgstr ""
 "(npr. Martin \"Chalky\" White). Oponaša staro webtrees ponašanje za stabla "
 "koja nadimke čuvaju u zasebnom polju GEDCOM NICK."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Samo bračno prezime"
 

--- a/resources/lang/sr-Latn/messages.po
+++ b/resources/lang/sr-Latn/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Prvo skrati lična imena"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Prvo skrati prezimena"
 
@@ -33,7 +33,7 @@ msgstr "Prvo skrati prezimena"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomaka pojedinca."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 
@@ -41,11 +41,11 @@ msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 msgid "Behavior"
 msgstr "Ponašanje"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Samo rodno ime"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Rodno ime sa bračnim prezimenom u zagradi"
 
@@ -133,7 +133,7 @@ msgstr ""
 "(npr. Martin \"Chalky\" White). Oponaša staro webtrees ponašanje za stabla "
 "koja nadimke čuvaju u zasebnom polju GEDCOM NICK."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Samo bračno prezime"
 
@@ -216,15 +216,15 @@ msgstr ""
 msgid "cancel"
 msgstr "odustani"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "dole"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "levo"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "desno"
 
@@ -232,7 +232,7 @@ msgstr "desno"
 msgid "save"
 msgstr "snimi"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "gore"
 

--- a/resources/lang/sr-Latn/messages.po
+++ b/resources/lang/sr-Latn/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Prvo skrati lična imena"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Prvo skrati prezimena"
 
@@ -33,7 +33,7 @@ msgstr "Prvo skrati prezimena"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomaka pojedinca."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 
@@ -41,11 +41,11 @@ msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 msgid "Behavior"
 msgstr "Ponašanje"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Samo rodno ime"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Rodno ime sa bračnim prezimenom u zagradi"
 
@@ -133,7 +133,7 @@ msgstr ""
 "(npr. Martin \"Chalky\" White). Oponaša staro webtrees ponašanje za stabla "
 "koja nadimke čuvaju u zasebnom polju GEDCOM NICK."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Samo bračno prezime"
 
@@ -216,15 +216,15 @@ msgstr ""
 msgid "cancel"
 msgstr "odustani"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "dole"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "levo"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "desno"
 
@@ -232,7 +232,7 @@ msgstr "desno"
 msgid "save"
 msgstr "snimi"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "gore"
 

--- a/resources/lang/sr-Latn/messages.po
+++ b/resources/lang/sr-Latn/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Prvo skrati lična imena"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Prvo skrati prezimena"
 
@@ -33,7 +33,7 @@ msgstr "Prvo skrati prezimena"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomaka pojedinca."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 
@@ -41,11 +41,11 @@ msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 msgid "Behavior"
 msgstr "Ponašanje"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Samo rodno ime"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Rodno ime sa bračnim prezimenom u zagradi"
 
@@ -133,7 +133,7 @@ msgstr ""
 "(npr. Martin \"Chalky\" White). Oponaša staro webtrees ponašanje za stabla "
 "koja nadimke čuvaju u zasebnom polju GEDCOM NICK."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Samo bračno prezime"
 

--- a/resources/lang/sr-Latn/messages.po
+++ b/resources/lang/sr-Latn/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Prvo skrati lična imena"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Prvo skrati prezimena"
 
@@ -33,7 +33,7 @@ msgstr "Prvo skrati prezimena"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomaka pojedinca."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 
@@ -41,11 +41,11 @@ msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 msgid "Behavior"
 msgstr "Ponašanje"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Samo rodno ime"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Rodno ime sa bračnim prezimenom u zagradi"
 
@@ -133,7 +133,7 @@ msgstr ""
 "(npr. Martin \"Chalky\" White). Oponaša staro webtrees ponašanje za stabla "
 "koja nadimke čuvaju u zasebnom polju GEDCOM NICK."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Samo bračno prezime"
 
@@ -216,15 +216,15 @@ msgstr ""
 msgid "cancel"
 msgstr "odustani"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "dole"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "levo"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "desno"
 
@@ -232,7 +232,7 @@ msgstr "desno"
 msgid "save"
 msgstr "snimi"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "gore"
 

--- a/resources/lang/sr-Latn/messages.po
+++ b/resources/lang/sr-Latn/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Prvo skrati lična imena"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Prvo skrati prezimena"
 
@@ -33,7 +33,7 @@ msgstr "Prvo skrati prezimena"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomaka pojedinca."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 
@@ -216,15 +216,15 @@ msgstr ""
 msgid "cancel"
 msgstr "odustani"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "dole"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "levo"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "desno"
 
@@ -232,7 +232,7 @@ msgstr "desno"
 msgid "save"
 msgstr "snimi"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "gore"
 

--- a/resources/lang/sr-Latn/messages.po
+++ b/resources/lang/sr-Latn/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Prvo skrati lična imena"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Prvo skrati prezimena"
 
@@ -33,7 +33,7 @@ msgstr "Prvo skrati prezimena"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomaka pojedinca."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 
@@ -41,11 +41,11 @@ msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 msgid "Behavior"
 msgstr "Ponašanje"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Samo rodno ime"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Rodno ime sa bračnim prezimenom u zagradi"
 
@@ -133,7 +133,7 @@ msgstr ""
 "(npr. Martin \"Chalky\" White). Oponaša staro webtrees ponašanje za stabla "
 "koja nadimke čuvaju u zasebnom polju GEDCOM NICK."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Samo bračno prezime"
 
@@ -216,15 +216,15 @@ msgstr ""
 msgid "cancel"
 msgstr "odustani"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "dole"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "levo"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "desno"
 
@@ -232,7 +232,7 @@ msgstr "desno"
 msgid "save"
 msgstr "snimi"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "gore"
 

--- a/resources/lang/sv/messages.po
+++ b/resources/lang/sv/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Förkorta förnamn först"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Förkorta efternamn först"
 
@@ -32,7 +32,7 @@ msgstr "Förkorta efternamn först"
 msgid "An overview of an individual’s descendants."
 msgstr "En översikt över en persons ättlingar."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 msgid "Behavior"
 msgstr "Beteende"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Endast födelsenamn"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Födelsenamn med giftasnamn inom parentes"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(t.ex. Martin \"Chalky\" White). Återskapar det tidigare webtrees-beteendet "
 "för träd som lagrar smeknamn i det separata GEDCOM NICK-fältet."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Endast giftasnamn"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "ner"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "vänster"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "höger"
 
@@ -231,7 +231,7 @@ msgstr "höger"
 msgid "save"
 msgstr "spara"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "upp"
 

--- a/resources/lang/sv/messages.po
+++ b/resources/lang/sv/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Förkorta förnamn först"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Förkorta efternamn först"
 
@@ -32,7 +32,7 @@ msgstr "Förkorta efternamn först"
 msgid "An overview of an individual’s descendants."
 msgstr "En översikt över en persons ättlingar."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 msgid "Behavior"
 msgstr "Beteende"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Endast födelsenamn"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Födelsenamn med giftasnamn inom parentes"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(t.ex. Martin \"Chalky\" White). Återskapar det tidigare webtrees-beteendet "
 "för träd som lagrar smeknamn i det separata GEDCOM NICK-fältet."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Endast giftasnamn"
 

--- a/resources/lang/sv/messages.po
+++ b/resources/lang/sv/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Förkorta förnamn först"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Förkorta efternamn först"
 
@@ -32,7 +32,7 @@ msgstr "Förkorta efternamn först"
 msgid "An overview of an individual’s descendants."
 msgstr "En översikt över en persons ättlingar."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "ner"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "vänster"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "höger"
 
@@ -231,7 +231,7 @@ msgstr "höger"
 msgid "save"
 msgstr "spara"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "upp"
 

--- a/resources/lang/sv/messages.po
+++ b/resources/lang/sv/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Förkorta förnamn först"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Förkorta efternamn först"
 
@@ -32,7 +32,7 @@ msgstr "Förkorta efternamn först"
 msgid "An overview of an individual’s descendants."
 msgstr "En översikt över en persons ättlingar."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 msgid "Behavior"
 msgstr "Beteende"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Endast födelsenamn"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Födelsenamn med giftasnamn inom parentes"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(t.ex. Martin \"Chalky\" White). Återskapar det tidigare webtrees-beteendet "
 "för träd som lagrar smeknamn i det separata GEDCOM NICK-fältet."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Endast giftasnamn"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "ner"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "vänster"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "höger"
 
@@ -231,7 +231,7 @@ msgstr "höger"
 msgid "save"
 msgstr "spara"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "upp"
 

--- a/resources/lang/sv/messages.po
+++ b/resources/lang/sv/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Förkorta förnamn först"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Förkorta efternamn först"
 
@@ -32,7 +32,7 @@ msgstr "Förkorta efternamn först"
 msgid "An overview of an individual’s descendants."
 msgstr "En översikt över en persons ättlingar."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 msgid "Behavior"
 msgstr "Beteende"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Endast födelsenamn"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Födelsenamn med giftasnamn inom parentes"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(t.ex. Martin \"Chalky\" White). Återskapar det tidigare webtrees-beteendet "
 "för träd som lagrar smeknamn i det separata GEDCOM NICK-fältet."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Endast giftasnamn"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "ner"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "vänster"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "höger"
 
@@ -231,7 +231,7 @@ msgstr "höger"
 msgid "save"
 msgstr "spara"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "upp"
 

--- a/resources/lang/sv/messages.po
+++ b/resources/lang/sv/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Förkorta förnamn först"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Förkorta efternamn först"
 
@@ -32,7 +32,7 @@ msgstr "Förkorta efternamn först"
 msgid "An overview of an individual’s descendants."
 msgstr "En översikt över en persons ättlingar."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 msgid "Behavior"
 msgstr "Beteende"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Endast födelsenamn"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Födelsenamn med giftasnamn inom parentes"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(t.ex. Martin \"Chalky\" White). Återskapar det tidigare webtrees-beteendet "
 "för träd som lagrar smeknamn i det separata GEDCOM NICK-fältet."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Endast giftasnamn"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "ner"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "vänster"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "höger"
 
@@ -231,7 +231,7 @@ msgstr "höger"
 msgid "save"
 msgstr "spara"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "upp"
 

--- a/resources/lang/sv/messages.po
+++ b/resources/lang/sv/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Förkorta förnamn först"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Förkorta efternamn först"
 
@@ -32,7 +32,7 @@ msgstr "Förkorta efternamn först"
 msgid "An overview of an individual’s descendants."
 msgstr "En översikt över en persons ättlingar."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 msgid "Behavior"
 msgstr "Beteende"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Endast födelsenamn"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Födelsenamn med giftasnamn inom parentes"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(t.ex. Martin \"Chalky\" White). Återskapar det tidigare webtrees-beteendet "
 "för träd som lagrar smeknamn i det separata GEDCOM NICK-fältet."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Endast giftasnamn"
 

--- a/resources/lang/uk/messages.po
+++ b/resources/lang/uk/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Спершу скорочувати імена"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Спершу скорочувати прізвища"
 
@@ -33,7 +33,7 @@ msgstr "Спершу скорочувати прізвища"
 msgid "An overview of an individual’s descendants."
 msgstr "Огляд нащадків персони у вигляді дерева."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматично (за традицією прізвищ дерева)"
 
@@ -216,15 +216,15 @@ msgstr ""
 msgid "cancel"
 msgstr "скасувати"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "вниз"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "ліворуч"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "праворуч"
 
@@ -232,7 +232,7 @@ msgstr "праворуч"
 msgid "save"
 msgstr "зберегти"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "вгору"
 

--- a/resources/lang/uk/messages.po
+++ b/resources/lang/uk/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Спершу скорочувати імена"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Спершу скорочувати прізвища"
 
@@ -33,7 +33,7 @@ msgstr "Спершу скорочувати прізвища"
 msgid "An overview of an individual’s descendants."
 msgstr "Огляд нащадків персони у вигляді дерева."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматично (за традицією прізвищ дерева)"
 
@@ -41,11 +41,11 @@ msgstr "Автоматично (за традицією прізвищ дере�
 msgid "Behavior"
 msgstr "Поведінка"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Лише ім'я при народженні"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Ім'я при народженні з прізвищем у шлюбі в дужках"
 
@@ -133,7 +133,7 @@ msgstr ""
 "Martin \"Chalky\" White). Повторює попередню поведінку webtrees для дерев, "
 "які зберігають прізвиська в окремому полі GEDCOM NICK."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Лише прізвище у шлюбі"
 
@@ -216,15 +216,15 @@ msgstr ""
 msgid "cancel"
 msgstr "скасувати"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "вниз"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "ліворуч"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "праворуч"
 
@@ -232,7 +232,7 @@ msgstr "праворуч"
 msgid "save"
 msgstr "зберегти"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "вгору"
 

--- a/resources/lang/uk/messages.po
+++ b/resources/lang/uk/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Спершу скорочувати імена"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Спершу скорочувати прізвища"
 
@@ -33,7 +33,7 @@ msgstr "Спершу скорочувати прізвища"
 msgid "An overview of an individual’s descendants."
 msgstr "Огляд нащадків персони у вигляді дерева."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматично (за традицією прізвищ дерева)"
 
@@ -41,11 +41,11 @@ msgstr "Автоматично (за традицією прізвищ дере�
 msgid "Behavior"
 msgstr "Поведінка"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Лише ім'я при народженні"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Ім'я при народженні з прізвищем у шлюбі в дужках"
 
@@ -133,7 +133,7 @@ msgstr ""
 "Martin \"Chalky\" White). Повторює попередню поведінку webtrees для дерев, "
 "які зберігають прізвиська в окремому полі GEDCOM NICK."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Лише прізвище у шлюбі"
 
@@ -216,15 +216,15 @@ msgstr ""
 msgid "cancel"
 msgstr "скасувати"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "вниз"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "ліворуч"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "праворуч"
 
@@ -232,7 +232,7 @@ msgstr "праворуч"
 msgid "save"
 msgstr "зберегти"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "вгору"
 

--- a/resources/lang/uk/messages.po
+++ b/resources/lang/uk/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Спершу скорочувати імена"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Спершу скорочувати прізвища"
 
@@ -33,7 +33,7 @@ msgstr "Спершу скорочувати прізвища"
 msgid "An overview of an individual’s descendants."
 msgstr "Огляд нащадків персони у вигляді дерева."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматично (за традицією прізвищ дерева)"
 
@@ -41,11 +41,11 @@ msgstr "Автоматично (за традицією прізвищ дере�
 msgid "Behavior"
 msgstr "Поведінка"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Лише ім'я при народженні"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Ім'я при народженні з прізвищем у шлюбі в дужках"
 
@@ -133,7 +133,7 @@ msgstr ""
 "Martin \"Chalky\" White). Повторює попередню поведінку webtrees для дерев, "
 "які зберігають прізвиська в окремому полі GEDCOM NICK."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Лише прізвище у шлюбі"
 
@@ -216,15 +216,15 @@ msgstr ""
 msgid "cancel"
 msgstr "скасувати"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "вниз"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "ліворуч"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "праворуч"
 
@@ -232,7 +232,7 @@ msgstr "праворуч"
 msgid "save"
 msgstr "зберегти"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "вгору"
 

--- a/resources/lang/uk/messages.po
+++ b/resources/lang/uk/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Спершу скорочувати імена"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Спершу скорочувати прізвища"
 
@@ -33,7 +33,7 @@ msgstr "Спершу скорочувати прізвища"
 msgid "An overview of an individual’s descendants."
 msgstr "Огляд нащадків персони у вигляді дерева."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматично (за традицією прізвищ дерева)"
 
@@ -41,11 +41,11 @@ msgstr "Автоматично (за традицією прізвищ дере�
 msgid "Behavior"
 msgstr "Поведінка"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Лише ім'я при народженні"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Ім'я при народженні з прізвищем у шлюбі в дужках"
 
@@ -133,7 +133,7 @@ msgstr ""
 "Martin \"Chalky\" White). Повторює попередню поведінку webtrees для дерев, "
 "які зберігають прізвиська в окремому полі GEDCOM NICK."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Лише прізвище у шлюбі"
 

--- a/resources/lang/uk/messages.po
+++ b/resources/lang/uk/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Спершу скорочувати імена"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Спершу скорочувати прізвища"
 
@@ -33,7 +33,7 @@ msgstr "Спершу скорочувати прізвища"
 msgid "An overview of an individual’s descendants."
 msgstr "Огляд нащадків персони у вигляді дерева."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматично (за традицією прізвищ дерева)"
 
@@ -41,11 +41,11 @@ msgstr "Автоматично (за традицією прізвищ дере�
 msgid "Behavior"
 msgstr "Поведінка"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Лише ім'я при народженні"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Ім'я при народженні з прізвищем у шлюбі в дужках"
 
@@ -133,7 +133,7 @@ msgstr ""
 "Martin \"Chalky\" White). Повторює попередню поведінку webtrees для дерев, "
 "які зберігають прізвиська в окремому полі GEDCOM NICK."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Лише прізвище у шлюбі"
 
@@ -216,15 +216,15 @@ msgstr ""
 msgid "cancel"
 msgstr "скасувати"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "вниз"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "ліворуч"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "праворуч"
 
@@ -232,7 +232,7 @@ msgstr "праворуч"
 msgid "save"
 msgstr "зберегти"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "вгору"
 

--- a/resources/lang/uk/messages.po
+++ b/resources/lang/uk/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Спершу скорочувати імена"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Спершу скорочувати прізвища"
 
@@ -33,7 +33,7 @@ msgstr "Спершу скорочувати прізвища"
 msgid "An overview of an individual’s descendants."
 msgstr "Огляд нащадків персони у вигляді дерева."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматично (за традицією прізвищ дерева)"
 
@@ -41,11 +41,11 @@ msgstr "Автоматично (за традицією прізвищ дере�
 msgid "Behavior"
 msgstr "Поведінка"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Лише ім'я при народженні"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Ім'я при народженні з прізвищем у шлюбі в дужках"
 
@@ -133,7 +133,7 @@ msgstr ""
 "Martin \"Chalky\" White). Повторює попередню поведінку webtrees для дерев, "
 "які зберігають прізвиська в окремому полі GEDCOM NICK."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Лише прізвище у шлюбі"
 

--- a/resources/lang/vi/messages.po
+++ b/resources/lang/vi/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "Viết tắt tên gọi trước"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "Viết tắt họ trước"
 
@@ -32,7 +32,7 @@ msgstr "Viết tắt họ trước"
 msgid "An overview of an individual’s descendants."
 msgstr "Tổng quan về con cháu của một cá nhân."
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 
@@ -40,11 +40,11 @@ msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 msgid "Behavior"
 msgstr "Hành vi"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "Chỉ tên khai sinh"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "Tên khai sinh kèm tên sau khi kết hôn trong ngoặc"
 
@@ -132,7 +132,7 @@ msgstr ""
 "Martin \"Chalky\" White). Tái hiện hành vi webtrees cũ cho cây gia phả lưu "
 "biệt danh trong trường GEDCOM NICK riêng."
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "Chỉ tên sau khi kết hôn"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Hủy bỏ"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "Từ trên xuống"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "Từ trái sang phải"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "Từ phải sang trái"
 
@@ -231,7 +231,7 @@ msgstr "Từ phải sang trái"
 msgid "save"
 msgstr "lưu"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "Từ dưới lên"
 

--- a/resources/lang/vi/messages.po
+++ b/resources/lang/vi/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Viết tắt tên gọi trước"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Viết tắt họ trước"
 
@@ -32,7 +32,7 @@ msgstr "Viết tắt họ trước"
 msgid "An overview of an individual’s descendants."
 msgstr "Tổng quan về con cháu của một cá nhân."
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 
@@ -40,11 +40,11 @@ msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 msgid "Behavior"
 msgstr "Hành vi"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Chỉ tên khai sinh"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Tên khai sinh kèm tên sau khi kết hôn trong ngoặc"
 
@@ -132,7 +132,7 @@ msgstr ""
 "Martin \"Chalky\" White). Tái hiện hành vi webtrees cũ cho cây gia phả lưu "
 "biệt danh trong trường GEDCOM NICK riêng."
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Chỉ tên sau khi kết hôn"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Hủy bỏ"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "Từ trên xuống"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "Từ trái sang phải"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "Từ phải sang trái"
 
@@ -231,7 +231,7 @@ msgstr "Từ phải sang trái"
 msgid "save"
 msgstr "lưu"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "Từ dưới lên"
 

--- a/resources/lang/vi/messages.po
+++ b/resources/lang/vi/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "Viết tắt tên gọi trước"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "Viết tắt họ trước"
 
@@ -32,7 +32,7 @@ msgstr "Viết tắt họ trước"
 msgid "An overview of an individual’s descendants."
 msgstr "Tổng quan về con cháu của một cá nhân."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 
@@ -40,11 +40,11 @@ msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 msgid "Behavior"
 msgstr "Hành vi"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "Chỉ tên khai sinh"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "Tên khai sinh kèm tên sau khi kết hôn trong ngoặc"
 
@@ -132,7 +132,7 @@ msgstr ""
 "Martin \"Chalky\" White). Tái hiện hành vi webtrees cũ cho cây gia phả lưu "
 "biệt danh trong trường GEDCOM NICK riêng."
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "Chỉ tên sau khi kết hôn"
 

--- a/resources/lang/vi/messages.po
+++ b/resources/lang/vi/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "Viết tắt tên gọi trước"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "Viết tắt họ trước"
 
@@ -32,7 +32,7 @@ msgstr "Viết tắt họ trước"
 msgid "An overview of an individual’s descendants."
 msgstr "Tổng quan về con cháu của một cá nhân."
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 
@@ -40,11 +40,11 @@ msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 msgid "Behavior"
 msgstr "Hành vi"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "Chỉ tên khai sinh"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "Tên khai sinh kèm tên sau khi kết hôn trong ngoặc"
 
@@ -132,7 +132,7 @@ msgstr ""
 "Martin \"Chalky\" White). Tái hiện hành vi webtrees cũ cho cây gia phả lưu "
 "biệt danh trong trường GEDCOM NICK riêng."
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "Chỉ tên sau khi kết hôn"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Hủy bỏ"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "Từ trên xuống"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "Từ trái sang phải"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "Từ phải sang trái"
 
@@ -231,7 +231,7 @@ msgstr "Từ phải sang trái"
 msgid "save"
 msgstr "lưu"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "Từ dưới lên"
 

--- a/resources/lang/vi/messages.po
+++ b/resources/lang/vi/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "Viết tắt tên gọi trước"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "Viết tắt họ trước"
 
@@ -32,7 +32,7 @@ msgstr "Viết tắt họ trước"
 msgid "An overview of an individual’s descendants."
 msgstr "Tổng quan về con cháu của một cá nhân."
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 
@@ -40,11 +40,11 @@ msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 msgid "Behavior"
 msgstr "Hành vi"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Chỉ tên khai sinh"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Tên khai sinh kèm tên sau khi kết hôn trong ngoặc"
 
@@ -132,7 +132,7 @@ msgstr ""
 "Martin \"Chalky\" White). Tái hiện hành vi webtrees cũ cho cây gia phả lưu "
 "biệt danh trong trường GEDCOM NICK riêng."
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Chỉ tên sau khi kết hôn"
 

--- a/resources/lang/vi/messages.po
+++ b/resources/lang/vi/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "Viết tắt tên gọi trước"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "Viết tắt họ trước"
 
@@ -32,7 +32,7 @@ msgstr "Viết tắt họ trước"
 msgid "An overview of an individual’s descendants."
 msgstr "Tổng quan về con cháu của một cá nhân."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 
@@ -40,11 +40,11 @@ msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 msgid "Behavior"
 msgstr "Hành vi"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "Chỉ tên khai sinh"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "Tên khai sinh kèm tên sau khi kết hôn trong ngoặc"
 
@@ -132,7 +132,7 @@ msgstr ""
 "Martin \"Chalky\" White). Tái hiện hành vi webtrees cũ cho cây gia phả lưu "
 "biệt danh trong trường GEDCOM NICK riêng."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "Chỉ tên sau khi kết hôn"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Hủy bỏ"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "Từ trên xuống"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "Từ trái sang phải"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "Từ phải sang trái"
 
@@ -231,7 +231,7 @@ msgstr "Từ phải sang trái"
 msgid "save"
 msgstr "lưu"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "Từ dưới lên"
 

--- a/resources/lang/vi/messages.po
+++ b/resources/lang/vi/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Viết tắt tên gọi trước"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Viết tắt họ trước"
 
@@ -32,7 +32,7 @@ msgstr "Viết tắt họ trước"
 msgid "An overview of an individual’s descendants."
 msgstr "Tổng quan về con cháu của một cá nhân."
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Hủy bỏ"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "Từ trên xuống"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "Từ trái sang phải"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "Từ phải sang trái"
 
@@ -231,7 +231,7 @@ msgstr "Từ phải sang trái"
 msgid "save"
 msgstr "lưu"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "Từ dưới lên"
 

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:412
 msgid "Abbreviate given names first"
 msgstr "优先缩写名字"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:413
 msgid "Abbreviate surnames first"
 msgstr "优先缩写姓氏"
 
@@ -30,7 +30,7 @@ msgstr "优先缩写姓氏"
 msgid "An overview of an individual’s descendants."
 msgstr "个人后代的概览图"
 
-#: src/Configuration.php:404
+#: src/Configuration.php:411
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "自动（根据族谱的姓氏传统）"
 
@@ -38,11 +38,11 @@ msgstr "自动（根据族谱的姓氏传统）"
 msgid "Behavior"
 msgstr "行为"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:277
 msgid "Birth name only"
 msgstr "仅出生姓名"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:279
 msgid "Birth name with married name in brackets"
 msgstr "出生姓名后附婚后姓名（括号内）"
 
@@ -130,7 +130,7 @@ msgstr ""
 "White）。模拟旧版 webtrees 的行为，适用于在单独的 GEDCOM NICK 字段中保存昵称"
 "的家谱。"
 
-#: src/Configuration.php:271
+#: src/Configuration.php:278
 msgid "Married name only"
 msgstr "仅婚后姓名"
 
@@ -214,15 +214,15 @@ msgstr ""
 msgid "cancel"
 msgstr "取消"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:200 src/Configuration.php:208
 msgid "down"
 msgstr "子孙在下"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:197 src/Configuration.php:205
 msgid "left"
 msgstr "子孙在左"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:198 src/Configuration.php:206
 msgid "right"
 msgstr "子孙在右"
 
@@ -230,7 +230,7 @@ msgstr "子孙在右"
 msgid "save"
 msgstr "保存"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:199 src/Configuration.php:207
 msgid "up"
 msgstr "子孙在上"
 

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Configuration.php:437
+#: src/Configuration.php:461
 msgid "Abbreviate given names first"
 msgstr "优先缩写名字"
 
-#: src/Configuration.php:438
+#: src/Configuration.php:462
 msgid "Abbreviate surnames first"
 msgstr "优先缩写姓氏"
 
@@ -30,7 +30,7 @@ msgstr "优先缩写姓氏"
 msgid "An overview of an individual’s descendants."
 msgstr "个人后代的概览图"
 
-#: src/Configuration.php:436
+#: src/Configuration.php:460
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "自动（根据族谱的姓氏传统）"
 
@@ -38,11 +38,11 @@ msgstr "自动（根据族谱的姓氏传统）"
 msgid "Behavior"
 msgstr "行为"
 
-#: src/Configuration.php:302
+#: src/Configuration.php:322
 msgid "Birth name only"
 msgstr "仅出生姓名"
 
-#: src/Configuration.php:304
+#: src/Configuration.php:324
 msgid "Birth name with married name in brackets"
 msgstr "出生姓名后附婚后姓名（括号内）"
 
@@ -130,7 +130,7 @@ msgstr ""
 "White）。模拟旧版 webtrees 的行为，适用于在单独的 GEDCOM NICK 字段中保存昵称"
 "的家谱。"
 
-#: src/Configuration.php:303
+#: src/Configuration.php:323
 msgid "Married name only"
 msgstr "仅婚后姓名"
 
@@ -214,15 +214,15 @@ msgstr ""
 msgid "cancel"
 msgstr "取消"
 
-#: src/Configuration.php:218 src/Configuration.php:226
+#: src/Configuration.php:234 src/Configuration.php:242
 msgid "down"
 msgstr "子孙在下"
 
-#: src/Configuration.php:215 src/Configuration.php:223
+#: src/Configuration.php:231 src/Configuration.php:239
 msgid "left"
 msgstr "子孙在左"
 
-#: src/Configuration.php:216 src/Configuration.php:224
+#: src/Configuration.php:232 src/Configuration.php:240
 msgid "right"
 msgstr "子孙在右"
 
@@ -230,7 +230,7 @@ msgstr "子孙在右"
 msgid "save"
 msgstr "保存"
 
-#: src/Configuration.php:217 src/Configuration.php:225
+#: src/Configuration.php:233 src/Configuration.php:241
 msgid "up"
 msgstr "子孙在上"
 

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Configuration.php:461
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "优先缩写名字"
 
-#: src/Configuration.php:462
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "优先缩写姓氏"
 
@@ -30,7 +30,7 @@ msgstr "优先缩写姓氏"
 msgid "An overview of an individual’s descendants."
 msgstr "个人后代的概览图"
 
-#: src/Configuration.php:460
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "自动（根据族谱的姓氏传统）"
 
@@ -38,11 +38,11 @@ msgstr "自动（根据族谱的姓氏传统）"
 msgid "Behavior"
 msgstr "行为"
 
-#: src/Configuration.php:322
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "仅出生姓名"
 
-#: src/Configuration.php:324
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "出生姓名后附婚后姓名（括号内）"
 
@@ -130,7 +130,7 @@ msgstr ""
 "White）。模拟旧版 webtrees 的行为，适用于在单独的 GEDCOM NICK 字段中保存昵称"
 "的家谱。"
 
-#: src/Configuration.php:323
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "仅婚后姓名"
 
@@ -214,15 +214,15 @@ msgstr ""
 msgid "cancel"
 msgstr "取消"
 
-#: src/Configuration.php:234 src/Configuration.php:242
+#: src/Configuration.php:244 src/Configuration.php:252
 msgid "down"
 msgstr "子孙在下"
 
-#: src/Configuration.php:231 src/Configuration.php:239
+#: src/Configuration.php:241 src/Configuration.php:249
 msgid "left"
 msgstr "子孙在左"
 
-#: src/Configuration.php:232 src/Configuration.php:240
+#: src/Configuration.php:242 src/Configuration.php:250
 msgid "right"
 msgstr "子孙在右"
 
@@ -230,7 +230,7 @@ msgstr "子孙在右"
 msgid "save"
 msgstr "保存"
 
-#: src/Configuration.php:233 src/Configuration.php:241
+#: src/Configuration.php:243 src/Configuration.php:251
 msgid "up"
 msgstr "子孙在上"
 

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:477
 msgid "Abbreviate given names first"
 msgstr "优先缩写名字"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:478
 msgid "Abbreviate surnames first"
 msgstr "优先缩写姓氏"
 
@@ -30,7 +30,7 @@ msgstr "优先缩写姓氏"
 msgid "An overview of an individual’s descendants."
 msgstr "个人后代的概览图"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:476
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "自动（根据族谱的姓氏传统）"
 
@@ -38,11 +38,11 @@ msgstr "自动（根据族谱的姓氏传统）"
 msgid "Behavior"
 msgstr "行为"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:330
 msgid "Birth name only"
 msgstr "仅出生姓名"
 
-#: src/Configuration.php:334
+#: src/Configuration.php:332
 msgid "Birth name with married name in brackets"
 msgstr "出生姓名后附婚后姓名（括号内）"
 
@@ -130,7 +130,7 @@ msgstr ""
 "White）。模拟旧版 webtrees 的行为，适用于在单独的 GEDCOM NICK 字段中保存昵称"
 "的家谱。"
 
-#: src/Configuration.php:333
+#: src/Configuration.php:331
 msgid "Married name only"
 msgstr "仅婚后姓名"
 

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Configuration.php:477
+#: src/Configuration.php:479
 msgid "Abbreviate given names first"
 msgstr "优先缩写名字"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:480
 msgid "Abbreviate surnames first"
 msgstr "优先缩写姓氏"
 
@@ -30,7 +30,7 @@ msgstr "优先缩写姓氏"
 msgid "An overview of an individual’s descendants."
 msgstr "个人后代的概览图"
 
-#: src/Configuration.php:476
+#: src/Configuration.php:478
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "自动（根据族谱的姓氏传统）"
 
@@ -38,11 +38,11 @@ msgstr "自动（根据族谱的姓氏传统）"
 msgid "Behavior"
 msgstr "行为"
 
-#: src/Configuration.php:330
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "仅出生姓名"
 
-#: src/Configuration.php:332
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "出生姓名后附婚后姓名（括号内）"
 
@@ -130,7 +130,7 @@ msgstr ""
 "White）。模拟旧版 webtrees 的行为，适用于在单独的 GEDCOM NICK 字段中保存昵称"
 "的家谱。"
 
-#: src/Configuration.php:331
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "仅婚后姓名"
 

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Configuration.php:412
+#: src/Configuration.php:437
 msgid "Abbreviate given names first"
 msgstr "优先缩写名字"
 
-#: src/Configuration.php:413
+#: src/Configuration.php:438
 msgid "Abbreviate surnames first"
 msgstr "优先缩写姓氏"
 
@@ -30,7 +30,7 @@ msgstr "优先缩写姓氏"
 msgid "An overview of an individual’s descendants."
 msgstr "个人后代的概览图"
 
-#: src/Configuration.php:411
+#: src/Configuration.php:436
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "自动（根据族谱的姓氏传统）"
 
@@ -38,11 +38,11 @@ msgstr "自动（根据族谱的姓氏传统）"
 msgid "Behavior"
 msgstr "行为"
 
-#: src/Configuration.php:277
+#: src/Configuration.php:302
 msgid "Birth name only"
 msgstr "仅出生姓名"
 
-#: src/Configuration.php:279
+#: src/Configuration.php:304
 msgid "Birth name with married name in brackets"
 msgstr "出生姓名后附婚后姓名（括号内）"
 
@@ -130,7 +130,7 @@ msgstr ""
 "White）。模拟旧版 webtrees 的行为，适用于在单独的 GEDCOM NICK 字段中保存昵称"
 "的家谱。"
 
-#: src/Configuration.php:278
+#: src/Configuration.php:303
 msgid "Married name only"
 msgstr "仅婚后姓名"
 
@@ -214,15 +214,15 @@ msgstr ""
 msgid "cancel"
 msgstr "取消"
 
-#: src/Configuration.php:200 src/Configuration.php:208
+#: src/Configuration.php:218 src/Configuration.php:226
 msgid "down"
 msgstr "子孙在下"
 
-#: src/Configuration.php:197 src/Configuration.php:205
+#: src/Configuration.php:215 src/Configuration.php:223
 msgid "left"
 msgstr "子孙在左"
 
-#: src/Configuration.php:198 src/Configuration.php:206
+#: src/Configuration.php:216 src/Configuration.php:224
 msgid "right"
 msgstr "子孙在右"
 
@@ -230,7 +230,7 @@ msgstr "子孙在右"
 msgid "save"
 msgstr "保存"
 
-#: src/Configuration.php:199 src/Configuration.php:207
+#: src/Configuration.php:217 src/Configuration.php:225
 msgid "up"
 msgstr "子孙在上"
 

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Configuration.php:479
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "优先缩写名字"
 
-#: src/Configuration.php:480
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "优先缩写姓氏"
 
@@ -30,7 +30,7 @@ msgstr "优先缩写姓氏"
 msgid "An overview of an individual’s descendants."
 msgstr "个人后代的概览图"
 
-#: src/Configuration.php:478
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "自动（根据族谱的姓氏传统）"
 
@@ -214,15 +214,15 @@ msgstr ""
 msgid "cancel"
 msgstr "取消"
 
-#: src/Configuration.php:244 src/Configuration.php:252
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "子孙在下"
 
-#: src/Configuration.php:241 src/Configuration.php:249
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "子孙在左"
 
-#: src/Configuration.php:242 src/Configuration.php:250
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "子孙在右"
 
@@ -230,7 +230,7 @@ msgstr "子孙在右"
 msgid "save"
 msgstr "保存"
 
-#: src/Configuration.php:243 src/Configuration.php:251
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "子孙在上"
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -94,30 +94,38 @@ class Configuration
         self::MARRIED_NAMES_BIRTH_AND_MARRIED,
     ];
 
+    // The five getters below are each called once per node while the tree is
+    // built. AbstractModule::getPreference() runs a `module_setting` query on
+    // every call and holds no cache, and Validator::__construct() re-scans all
+    // request parameters for valid UTF-8, so both costs would scale with the
+    // size of the chart. Each getter therefore returns its memoised value
+    // before doing either — an assignment at the return site would be too
+    // late, because the validator is built above it.
+
     /**
-     * Memoised preference lookups, each resolved on first use.
-     *
-     * Every one of these getters is called once per node while the tree is
-     * built, and AbstractModule::getPreference() runs a `module_setting` query
-     * on each call without a cache of its own — so without memoisation the
-     * query count grows with the size of the chart.
+     * The resolved number of generations to display.
      */
     private ?int $generations = null;
 
+    /**
+     * The resolved tree layout.
+     */
     private ?string $layout = null;
 
+    /**
+     * Whether spouses are hidden.
+     */
     private ?bool $hideSpouses = null;
 
+    /**
+     * The resolved married-names display mode.
+     */
     private ?string $marriedNamesMode = null;
 
-    private ?bool $showNicknames = null;
-
     /**
-     * The memoised route parameters, resolved on first use.
-     *
-     * @var array{generations: int, layout: string, hideSpouses: string, marriedNamesMode: string, showNicknames: string}|null
+     * Whether nicknames are shown.
      */
-    private ?array $routeToggleParams = null;
+    private ?bool $showNicknames = null;
 
     /**
      * Configuration constructor.
@@ -141,13 +149,17 @@ class Configuration
      */
     public function getGenerations(): int
     {
+        if ($this->generations !== null) {
+            return $this->generations;
+        }
+
         if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
             $validator = Validator::parsedBody($this->request);
         } else {
             $validator = Validator::queryParams($this->request);
         }
 
-        return $this->generations ??= $validator
+        return $this->generations = $validator
             ->isBetween(self::MIN_GENERATIONS, self::MAX_GENERATIONS)
             ->integer(
                 'generations',
@@ -181,13 +193,17 @@ class Configuration
      */
     public function getLayout(): string
     {
+        if ($this->layout !== null) {
+            return $this->layout;
+        }
+
         if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
             $validator = Validator::parsedBody($this->request);
         } else {
             $validator = Validator::queryParams($this->request);
         }
 
-        return $this->layout ??= $validator
+        return $this->layout = $validator
             ->isInArray([
                 self::LAYOUT_BOTTOMTOP,
                 self::LAYOUT_LEFTRIGHT,
@@ -234,13 +250,17 @@ class Configuration
      */
     public function getHideSpouses(): bool
     {
+        if ($this->hideSpouses !== null) {
+            return $this->hideSpouses;
+        }
+
         if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
             $validator = Validator::parsedBody($this->request);
         } else {
             $validator = Validator::queryParams($this->request);
         }
 
-        return $this->hideSpouses ??= $validator
+        return $this->hideSpouses = $validator
             ->boolean(
                 'hideSpouses',
                 (bool) $this->module->getPreference(
@@ -339,13 +359,17 @@ class Configuration
      */
     public function getShowNicknames(): bool
     {
+        if ($this->showNicknames !== null) {
+            return $this->showNicknames;
+        }
+
         if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
             $validator = Validator::parsedBody($this->request);
         } else {
             $validator = Validator::queryParams($this->request);
         }
 
-        return $this->showNicknames ??= $validator
+        return $this->showNicknames = $validator
             ->boolean(
                 'showNicknames',
                 (bool) $this->module->getPreference(
@@ -489,7 +513,7 @@ class Configuration
      */
     public function getRouteToggleParams(): array
     {
-        return $this->routeToggleParams ??= [
+        return [
             'generations'      => $this->getGenerations(),
             'layout'           => $this->getLayout(),
             'hideSpouses'      => $this->getHideSpouses() ? '1' : '0',

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -436,4 +436,27 @@ class Configuration
             ? $value
             : NameAbbreviation::AUTO;
     }
+
+    /**
+     * Returns the settings that have to travel with the re-centering URL.
+     *
+     * The update route rebuilds the node data server-side, so every setting the
+     * data facade reads while building it must be forwarded — otherwise
+     * clicking a person to re-center silently resets that setting to the module
+     * preference default. Settings the browser applies on its own (name
+     * abbreviation, alternative names) live in the client-side chart options and
+     * are deliberately not listed here.
+     *
+     * @return array<string, int|string>
+     */
+    public function getRouteToggleParams(): array
+    {
+        return [
+            'generations'      => $this->getGenerations(),
+            'layout'           => $this->getLayout(),
+            'hideSpouses'      => $this->getHideSpouses() ? '1' : '0',
+            'marriedNamesMode' => $this->getMarriedNamesMode(),
+            'showNicknames'    => $this->getShowNicknames() ? '1' : '0',
+        ];
+    }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -313,9 +313,11 @@ class Configuration
 
         $mode = $validator->string('marriedNamesMode', $default);
 
-        return $this->marriedNamesMode = in_array($mode, self::MARRIED_NAMES_MODES, true)
+        $this->marriedNamesMode = in_array($mode, self::MARRIED_NAMES_MODES, true)
             ? $mode
             : self::MARRIED_NAMES_OFF;
+
+        return $this->marriedNamesMode;
     }
 
     /**

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -95,6 +95,13 @@ class Configuration
     ];
 
     /**
+     * The memoised route parameters, resolved on first use.
+     *
+     * @var array{generations: int, layout: string, hideSpouses: string, marriedNamesMode: string, showNicknames: string}|null
+     */
+    private ?array $routeToggleParams = null;
+
+    /**
      * Configuration constructor.
      *
      * @param ServerRequestInterface $request
@@ -447,11 +454,17 @@ class Configuration
      * abbreviation, alternative names) live in the client-side chart options and
      * are deliberately not listed here.
      *
-     * @return array<string, int|string>
+     * Memoised because the update route is built once per node, while
+     * AbstractModule::getPreference() issues a database query on every call —
+     * resolving five settings per node would put the query count in linear
+     * proportion to the tree size. The configuration is constructed per request,
+     * so the resolved values cannot go stale within its lifetime.
+     *
+     * @return array{generations: int, layout: string, hideSpouses: string, marriedNamesMode: string, showNicknames: string}
      */
     public function getRouteToggleParams(): array
     {
-        return [
+        return $this->routeToggleParams ??= [
             'generations'      => $this->getGenerations(),
             'layout'           => $this->getLayout(),
             'hideSpouses'      => $this->getHideSpouses() ? '1' : '0',

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -94,7 +94,7 @@ class Configuration
         self::MARRIED_NAMES_BIRTH_AND_MARRIED,
     ];
 
-    // The five getters below are each called once per node while the tree is
+    // The seven getters below are each called once per node while the tree is
     // built. AbstractModule::getPreference() runs a `module_setting` query on
     // every call and holds no cache, and Validator::__construct() re-scans all
     // request parameters for valid UTF-8, so both costs would scale with the
@@ -103,37 +103,37 @@ class Configuration
     // late, because the validator is built above it.
 
     /**
-     * The resolved number of generations to display.
+     * The resolved number of generations to display, or null until first resolved.
      */
     private ?int $generations = null;
 
     /**
-     * The resolved tree layout.
+     * The resolved tree layout, or null until first resolved.
      */
     private ?string $layout = null;
 
     /**
-     * Whether spouses are hidden.
+     * Whether spouses are hidden, or null until first resolved.
      */
     private ?bool $hideSpouses = null;
 
     /**
-     * The resolved married-names display mode.
+     * The resolved married-names display mode, or null until first resolved.
      */
     private ?string $marriedNamesMode = null;
 
     /**
-     * Whether nicknames are shown.
+     * Whether nicknames are shown, or null until first resolved.
      */
     private ?bool $showNicknames = null;
 
     /**
-     * Whether a click opens a new tab.
+     * Whether a click opens a new tab, or null until first resolved.
      */
     private ?bool $openNewTabOnClick = null;
 
     /**
-     * Whether the alternative name is shown.
+     * Whether the alternative name is shown, or null until first resolved.
      */
     private ?bool $showAlternativeName = null;
 
@@ -294,9 +294,7 @@ class Configuration
      */
     public function getMarriedNamesMode(): string
     {
-        // Returns before touching the preferences on purpose. The two
-        // getPreference() calls below each run a query, and memoising only the
-        // final return would not spare them — they are evaluated first.
+        // This getter resolves TWO preferences, the legacy one included.
         if ($this->marriedNamesMode !== null) {
             return $this->marriedNamesMode;
         }
@@ -514,16 +512,19 @@ class Configuration
     /**
      * Returns the settings that have to travel with the re-centering URL.
      *
-     * The update route rebuilds the node data server-side, so every setting the
-     * data facade reads while building it must be forwarded — otherwise
-     * clicking a person to re-center silently resets that setting to the module
-     * preference default. Settings the browser applies on its own (name
-     * abbreviation, alternative names) live in the client-side chart options and
-     * are deliberately not listed here.
+     * Clicking a person navigates to the page route afresh, so every setting the
+     * re-centered page has to restore must travel in the URL — otherwise that
+     * setting silently falls back to the module preference default. The list is
+     * therefore the user-settable form fields, not just what the data facade
+     * reads: `openNewTabOnClick` and `showAlternativeName` are resolved by the
+     * view rather than the facade and still have to be forwarded.
      *
-     * Memoised because the update route is built once per node, while
-     * AbstractModule::getPreference() issues a database query on every call —
-     * resolving five settings per node would put the query count in linear
+     * `nameAbbreviation` is deliberately absent — it is an admin preference with
+     * no form field, so it resolves identically on the re-centered page.
+     *
+     * Cheap to call per node even though it resolves seven settings: each getter
+     * memoises its value, and AbstractModule::getPreference() would otherwise
+     * issue a database query on every call, putting the query count in linear
      * proportion to the tree size. The configuration is constructed per request,
      * so the resolved values cannot go stale within its lifetime.
      *

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -153,6 +153,22 @@ class Configuration
     }
 
     /**
+     * Returns the validator for whichever side of the request carries the
+     * parameters.
+     *
+     * Not memoised: every caller is a getter that returns its own memoised value
+     * before reaching this, so it runs at most once per setting per request.
+     */
+    private function requestValidator(): Validator
+    {
+        if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
+            return Validator::parsedBody($this->request);
+        }
+
+        return Validator::queryParams($this->request);
+    }
+
+    /**
      * Returns the number of generations to display.
      *
      * @return int
@@ -163,11 +179,7 @@ class Configuration
             return $this->generations;
         }
 
-        if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
-            $validator = Validator::parsedBody($this->request);
-        } else {
-            $validator = Validator::queryParams($this->request);
-        }
+        $validator = $this->requestValidator();
 
         return $this->generations = $validator
             ->isBetween(self::MIN_GENERATIONS, self::MAX_GENERATIONS)
@@ -207,11 +219,7 @@ class Configuration
             return $this->layout;
         }
 
-        if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
-            $validator = Validator::parsedBody($this->request);
-        } else {
-            $validator = Validator::queryParams($this->request);
-        }
+        $validator = $this->requestValidator();
 
         return $this->layout = $validator
             ->isInArray([
@@ -264,11 +272,7 @@ class Configuration
             return $this->hideSpouses;
         }
 
-        if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
-            $validator = Validator::parsedBody($this->request);
-        } else {
-            $validator = Validator::queryParams($this->request);
-        }
+        $validator = $this->requestValidator();
 
         return $this->hideSpouses = $validator
             ->boolean(
@@ -299,11 +303,7 @@ class Configuration
             return $this->marriedNamesMode;
         }
 
-        if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
-            $validator = Validator::parsedBody($this->request);
-        } else {
-            $validator = Validator::queryParams($this->request);
-        }
+        $validator = $this->requestValidator();
 
         $legacyDefault = ((bool) $this->module->getPreference('default_showMarriedNames', '0'))
             ? self::MARRIED_NAMES_ONLY
@@ -347,11 +347,7 @@ class Configuration
             return $this->openNewTabOnClick;
         }
 
-        if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
-            $validator = Validator::parsedBody($this->request);
-        } else {
-            $validator = Validator::queryParams($this->request);
-        }
+        $validator = $this->requestValidator();
 
         return $this->openNewTabOnClick = $validator
             ->boolean(
@@ -377,11 +373,7 @@ class Configuration
             return $this->showNicknames;
         }
 
-        if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
-            $validator = Validator::parsedBody($this->request);
-        } else {
-            $validator = Validator::queryParams($this->request);
-        }
+        $validator = $this->requestValidator();
 
         return $this->showNicknames = $validator
             ->boolean(
@@ -404,11 +396,7 @@ class Configuration
             return $this->showAlternativeName;
         }
 
-        if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
-            $validator = Validator::parsedBody($this->request);
-        } else {
-            $validator = Validator::queryParams($this->request);
-        }
+        $validator = $this->requestValidator();
 
         return $this->showAlternativeName = $validator
             ->boolean(
@@ -427,11 +415,7 @@ class Configuration
      */
     public function getHideSvgExport(): bool
     {
-        if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
-            $validator = Validator::parsedBody($this->request);
-        } else {
-            $validator = Validator::queryParams($this->request);
-        }
+        $validator = $this->requestValidator();
 
         return $validator
             ->boolean(
@@ -450,11 +434,7 @@ class Configuration
      */
     public function getHidePngExport(): bool
     {
-        if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
-            $validator = Validator::parsedBody($this->request);
-        } else {
-            $validator = Validator::queryParams($this->request);
-        }
+        $validator = $this->requestValidator();
 
         return $validator
             ->boolean(
@@ -491,11 +471,7 @@ class Configuration
      */
     public function getNameAbbreviation(): string
     {
-        if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
-            $validator = Validator::parsedBody($this->request);
-        } else {
-            $validator = Validator::queryParams($this->request);
-        }
+        $validator = $this->requestValidator();
 
         $value = $validator
             ->string(

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -95,6 +95,24 @@ class Configuration
     ];
 
     /**
+     * Memoised preference lookups, each resolved on first use.
+     *
+     * Every one of these getters is called once per node while the tree is
+     * built, and AbstractModule::getPreference() runs a `module_setting` query
+     * on each call without a cache of its own — so without memoisation the
+     * query count grows with the size of the chart.
+     */
+    private ?int $generations = null;
+
+    private ?string $layout = null;
+
+    private ?bool $hideSpouses = null;
+
+    private ?string $marriedNamesMode = null;
+
+    private ?bool $showNicknames = null;
+
+    /**
      * The memoised route parameters, resolved on first use.
      *
      * @var array{generations: int, layout: string, hideSpouses: string, marriedNamesMode: string, showNicknames: string}|null
@@ -129,7 +147,7 @@ class Configuration
             $validator = Validator::queryParams($this->request);
         }
 
-        return $validator
+        return $this->generations ??= $validator
             ->isBetween(self::MIN_GENERATIONS, self::MAX_GENERATIONS)
             ->integer(
                 'generations',
@@ -169,7 +187,7 @@ class Configuration
             $validator = Validator::queryParams($this->request);
         }
 
-        return $validator
+        return $this->layout ??= $validator
             ->isInArray([
                 self::LAYOUT_BOTTOMTOP,
                 self::LAYOUT_LEFTRIGHT,
@@ -222,7 +240,7 @@ class Configuration
             $validator = Validator::queryParams($this->request);
         }
 
-        return $validator
+        return $this->hideSpouses ??= $validator
             ->boolean(
                 'hideSpouses',
                 (bool) $this->module->getPreference(
@@ -246,6 +264,13 @@ class Configuration
      */
     public function getMarriedNamesMode(): string
     {
+        // Returns before touching the preferences on purpose. The two
+        // getPreference() calls below each run a query, and memoising only the
+        // final return would not spare them — they are evaluated first.
+        if ($this->marriedNamesMode !== null) {
+            return $this->marriedNamesMode;
+        }
+
         if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
             $validator = Validator::parsedBody($this->request);
         } else {
@@ -260,7 +285,7 @@ class Configuration
 
         $mode = $validator->string('marriedNamesMode', $default);
 
-        return in_array($mode, self::MARRIED_NAMES_MODES, true)
+        return $this->marriedNamesMode = in_array($mode, self::MARRIED_NAMES_MODES, true)
             ? $mode
             : self::MARRIED_NAMES_OFF;
     }
@@ -320,7 +345,7 @@ class Configuration
             $validator = Validator::queryParams($this->request);
         }
 
-        return $validator
+        return $this->showNicknames ??= $validator
             ->boolean(
                 'showNicknames',
                 (bool) $this->module->getPreference(

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -128,6 +128,16 @@ class Configuration
     private ?bool $showNicknames = null;
 
     /**
+     * Whether a click opens a new tab.
+     */
+    private ?bool $openNewTabOnClick = null;
+
+    /**
+     * Whether the alternative name is shown.
+     */
+    private ?bool $showAlternativeName = null;
+
+    /**
      * Configuration constructor.
      *
      * @param ServerRequestInterface $request
@@ -333,13 +343,17 @@ class Configuration
      */
     public function getOpenNewTabOnClick(): bool
     {
+        if ($this->openNewTabOnClick !== null) {
+            return $this->openNewTabOnClick;
+        }
+
         if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
             $validator = Validator::parsedBody($this->request);
         } else {
             $validator = Validator::queryParams($this->request);
         }
 
-        return $validator
+        return $this->openNewTabOnClick = $validator
             ->boolean(
                 'openNewTabOnClick',
                 (bool) $this->module->getPreference(
@@ -386,13 +400,17 @@ class Configuration
      */
     public function getShowAlternativeName(): bool
     {
+        if ($this->showAlternativeName !== null) {
+            return $this->showAlternativeName;
+        }
+
         if ($this->request->getMethod() === RequestMethodInterface::METHOD_POST) {
             $validator = Validator::parsedBody($this->request);
         } else {
             $validator = Validator::queryParams($this->request);
         }
 
-        return $validator
+        return $this->showAlternativeName = $validator
             ->boolean(
                 'showAlternativeName',
                 (bool) $this->module->getPreference(
@@ -509,16 +527,18 @@ class Configuration
      * proportion to the tree size. The configuration is constructed per request,
      * so the resolved values cannot go stale within its lifetime.
      *
-     * @return array{generations: int, layout: string, hideSpouses: string, marriedNamesMode: string, showNicknames: string}
+     * @return array{generations: int, layout: string, hideSpouses: string, marriedNamesMode: string, showNicknames: string, openNewTabOnClick: string, showAlternativeName: string}
      */
     public function getRouteToggleParams(): array
     {
         return [
-            'generations'      => $this->getGenerations(),
-            'layout'           => $this->getLayout(),
-            'hideSpouses'      => $this->getHideSpouses() ? '1' : '0',
-            'marriedNamesMode' => $this->getMarriedNamesMode(),
-            'showNicknames'    => $this->getShowNicknames() ? '1' : '0',
+            'generations'         => $this->getGenerations(),
+            'layout'              => $this->getLayout(),
+            'hideSpouses'         => $this->getHideSpouses() ? '1' : '0',
+            'marriedNamesMode'    => $this->getMarriedNamesMode(),
+            'showNicknames'       => $this->getShowNicknames() ? '1' : '0',
+            'openNewTabOnClick'   => $this->getOpenNewTabOnClick() ? '1' : '0',
+            'showAlternativeName' => $this->getShowAlternativeName() ? '1' : '0',
         ];
     }
 }

--- a/src/Facade/DataFacade.php
+++ b/src/Facade/DataFacade.php
@@ -276,17 +276,14 @@ class DataFacade
 
     /**
      * Builds the AJAX update route stamped onto each NodeData, so clicking a
-     * descendant re-centers the chart while preserving generation and layout
-     * selections.
+     * descendant re-centers the chart while preserving every display setting
+     * the node data depends on.
      */
     private function getUpdateRoute(Individual $individual): string
     {
         return $this->chartUrl(
             $individual,
-            [
-                'generations' => $this->configuration->getGenerations(),
-                'layout'      => $this->configuration->getLayout(),
-            ]
+            $this->configuration->getRouteToggleParams()
         );
     }
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -191,22 +191,26 @@ final class ConfigurationTest extends TestCase
     {
         $configuration = $this->buildConfiguration(
             [
-                'generations'      => '5',
-                'layout'           => Configuration::LAYOUT_TOPBOTTOM,
-                'hideSpouses'      => '1',
-                'marriedNamesMode' => Configuration::MARRIED_NAMES_ONLY,
-                'showNicknames'    => '1',
+                'generations'         => '5',
+                'layout'              => Configuration::LAYOUT_TOPBOTTOM,
+                'hideSpouses'         => '1',
+                'marriedNamesMode'    => Configuration::MARRIED_NAMES_ONLY,
+                'showNicknames'       => '1',
+                'openNewTabOnClick'   => '1',
+                'showAlternativeName' => '1',
             ],
             []
         );
 
         self::assertSame(
             [
-                'generations'      => 5,
-                'layout'           => Configuration::LAYOUT_TOPBOTTOM,
-                'hideSpouses'      => '1',
-                'marriedNamesMode' => Configuration::MARRIED_NAMES_ONLY,
-                'showNicknames'    => '1',
+                'generations'         => 5,
+                'layout'              => Configuration::LAYOUT_TOPBOTTOM,
+                'hideSpouses'         => '1',
+                'marriedNamesMode'    => Configuration::MARRIED_NAMES_ONLY,
+                'showNicknames'       => '1',
+                'openNewTabOnClick'   => '1',
+                'showAlternativeName' => '1',
             ],
             $configuration->getRouteToggleParams()
         );
@@ -222,22 +226,26 @@ final class ConfigurationTest extends TestCase
     {
         $configuration = $this->buildConfiguration(
             [
-                'generations'      => '3',
-                'layout'           => Configuration::LAYOUT_LEFTRIGHT,
-                'hideSpouses'      => '0',
-                'marriedNamesMode' => Configuration::MARRIED_NAMES_OFF,
-                'showNicknames'    => '0',
+                'generations'         => '3',
+                'layout'              => Configuration::LAYOUT_LEFTRIGHT,
+                'hideSpouses'         => '0',
+                'marriedNamesMode'    => Configuration::MARRIED_NAMES_OFF,
+                'showNicknames'       => '0',
+                'openNewTabOnClick'   => '0',
+                'showAlternativeName' => '0',
             ],
             []
         );
 
         self::assertSame(
             [
-                'generations'      => 3,
-                'layout'           => Configuration::LAYOUT_LEFTRIGHT,
-                'hideSpouses'      => '0',
-                'marriedNamesMode' => Configuration::MARRIED_NAMES_OFF,
-                'showNicknames'    => '0',
+                'generations'         => 3,
+                'layout'              => Configuration::LAYOUT_LEFTRIGHT,
+                'hideSpouses'         => '0',
+                'marriedNamesMode'    => Configuration::MARRIED_NAMES_OFF,
+                'showNicknames'       => '0',
+                'openNewTabOnClick'   => '0',
+                'showAlternativeName' => '0',
             ],
             $configuration->getRouteToggleParams()
         );
@@ -254,21 +262,25 @@ final class ConfigurationTest extends TestCase
         $configuration = $this->buildConfiguration(
             [],
             [
-                'default_generations'      => '7',
-                'default_layout'           => Configuration::LAYOUT_RIGHTLEFT,
-                'default_hideSpouses'      => '1',
-                'default_marriedNamesMode' => Configuration::MARRIED_NAMES_BIRTH_AND_MARRIED,
-                'default_showNicknames'    => '1',
+                'default_generations'         => '7',
+                'default_layout'              => Configuration::LAYOUT_RIGHTLEFT,
+                'default_hideSpouses'         => '1',
+                'default_marriedNamesMode'    => Configuration::MARRIED_NAMES_BIRTH_AND_MARRIED,
+                'default_showNicknames'       => '1',
+                'default_openNewTabOnClick'   => '0',
+                'default_showAlternativeName' => '1',
             ]
         );
 
         self::assertSame(
             [
-                'generations'      => 7,
-                'layout'           => Configuration::LAYOUT_RIGHTLEFT,
-                'hideSpouses'      => '1',
-                'marriedNamesMode' => Configuration::MARRIED_NAMES_BIRTH_AND_MARRIED,
-                'showNicknames'    => '1',
+                'generations'         => 7,
+                'layout'              => Configuration::LAYOUT_RIGHTLEFT,
+                'hideSpouses'         => '1',
+                'marriedNamesMode'    => Configuration::MARRIED_NAMES_BIRTH_AND_MARRIED,
+                'showNicknames'       => '1',
+                'openNewTabOnClick'   => '0',
+                'showAlternativeName' => '1',
             ],
             $configuration->getRouteToggleParams()
         );

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -26,9 +26,12 @@ use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
 /**
- * Verifies the married-names display mode resolution: explicit request value,
- * fallback to the new module preference, migration from the legacy
- * `default_showMarriedNames` boolean, and rejection of invalid values.
+ * Verifies how Configuration resolves request parameters and module
+ * preferences: the married-names display mode (explicit request value, the new
+ * preference, migration from the legacy `default_showMarriedNames` boolean,
+ * rejection of invalid values), the settings forwarded on the re-centering
+ * route, and the per-request memoisation that keeps the preference query count
+ * independent of the tree size.
  *
  * Uses an in-memory SQLite DB because AbstractModule::getPreference() is final
  * and cannot be stubbed; the real implementation reads from the
@@ -217,9 +220,15 @@ final class ConfigurationTest extends TestCase
     }
 
     /**
-     * The disabled polarity, which the enabled case cannot discriminate: with
-     * both toggles on, a raw passthrough of the query parameters would produce
-     * the same result as the intended mapping.
+     * The disabled polarity. `openNewTabOnClick` defaults to on
+     * (`default_openNewTabOnClick` is '1'), so an implementation that ignored the
+     * request parameter and resolved from the preference alone would emit '1'
+     * here — this case is what forces the request value to win, and pins the
+     * bool-to-string mapping in the other direction.
+     *
+     * It does not discriminate a raw passthrough of the query parameters: those
+     * are '0' and so is the expectation. Passthrough is caught by `generations`
+     * (string in, int out) and by the empty-request case.
      */
     #[Test]
     public function routeParamsCarryTheDisabledDisplaySettings(): void

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -181,12 +181,13 @@ final class ConfigurationTest extends TestCase
     }
 
     /**
-     * The re-centering URL is rebuilt from these parameters. Every setting the
-     * data facade reads while building node data has to appear here, otherwise
-     * clicking a person silently resets it to the module preference default.
+     * The enabled polarity. The boolean settings have to leave as the strings
+     * `'1'`/`'0'`, because `Validator::boolean()` compares strictly — an int
+     * would match neither branch and fall back to the preference default, which
+     * is the very regression this list prevents.
      */
     #[Test]
-    public function routeToggleParamsCarryEverySettingTheFacadeReads(): void
+    public function routeParamsCarryTheEnabledDisplaySettings(): void
     {
         $configuration = $this->buildConfiguration(
             [
@@ -205,6 +206,68 @@ final class ConfigurationTest extends TestCase
                 'layout'           => Configuration::LAYOUT_TOPBOTTOM,
                 'hideSpouses'      => '1',
                 'marriedNamesMode' => Configuration::MARRIED_NAMES_ONLY,
+                'showNicknames'    => '1',
+            ],
+            $configuration->getRouteToggleParams()
+        );
+    }
+
+    /**
+     * The disabled polarity, which the enabled case cannot discriminate: with
+     * both toggles on, a raw passthrough of the query parameters would produce
+     * the same result as the intended mapping.
+     */
+    #[Test]
+    public function routeParamsCarryTheDisabledDisplaySettings(): void
+    {
+        $configuration = $this->buildConfiguration(
+            [
+                'generations'      => '3',
+                'layout'           => Configuration::LAYOUT_LEFTRIGHT,
+                'hideSpouses'      => '0',
+                'marriedNamesMode' => Configuration::MARRIED_NAMES_OFF,
+                'showNicknames'    => '0',
+            ],
+            []
+        );
+
+        self::assertSame(
+            [
+                'generations'      => 3,
+                'layout'           => Configuration::LAYOUT_LEFTRIGHT,
+                'hideSpouses'      => '0',
+                'marriedNamesMode' => Configuration::MARRIED_NAMES_OFF,
+                'showNicknames'    => '0',
+            ],
+            $configuration->getRouteToggleParams()
+        );
+    }
+
+    /**
+     * The scenario the forwarding exists for: without any request parameter the
+     * effective value is the module preference, and that resolved value — not an
+     * echo of the URL — is what has to travel on.
+     */
+    #[Test]
+    public function routeParamsResolveFromModulePreferencesWhenTheRequestIsEmpty(): void
+    {
+        $configuration = $this->buildConfiguration(
+            [],
+            [
+                'default_generations'      => '7',
+                'default_layout'           => Configuration::LAYOUT_RIGHTLEFT,
+                'default_hideSpouses'      => '1',
+                'default_marriedNamesMode' => Configuration::MARRIED_NAMES_BIRTH_AND_MARRIED,
+                'default_showNicknames'    => '1',
+            ]
+        );
+
+        self::assertSame(
+            [
+                'generations'      => 7,
+                'layout'           => Configuration::LAYOUT_RIGHTLEFT,
+                'hideSpouses'      => '1',
+                'marriedNamesMode' => Configuration::MARRIED_NAMES_BIRTH_AND_MARRIED,
                 'showNicknames'    => '1',
             ],
             $configuration->getRouteToggleParams()

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -310,7 +310,7 @@ final class ConfigurationTest extends TestCase
     }
 
     /**
-     * Runs the per-node getters $rounds times against a FRESH configuration and
+     * Runs all seven per-node getters $rounds times against a FRESH configuration and
      * returns how many `module_setting` queries that produced. The instance has
      * to be fresh per measurement — reusing one would leave it memoised from the
      * previous round and report zero.
@@ -329,6 +329,8 @@ final class ConfigurationTest extends TestCase
                 $configuration->getHideSpouses();
                 $configuration->getMarriedNamesMode();
                 $configuration->getShowNicknames();
+                $configuration->getOpenNewTabOnClick();
+                $configuration->getShowAlternativeName();
             }
 
             // Counts only the preference reads the assertion talks about, so an

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -273,4 +273,36 @@ final class ConfigurationTest extends TestCase
             $configuration->getRouteToggleParams()
         );
     }
+
+    #[Test]
+    public function readsEachPreferenceAtMostOncePerRequest(): void
+    {
+        $configuration = $this->buildConfiguration([], []);
+
+        // Every getter here is called once per node while the tree is built, and
+        // AbstractModule::getPreference() runs a `module_setting` query on every
+        // call — it holds no cache of its own. Without memoisation the query
+        // count therefore grows with the size of the chart. Ten rounds stand in
+        // for ten nodes: unmemoised that is 40+ queries, memoised it is at most
+        // one per distinct preference.
+        DB::connection()->flushQueryLog();
+        DB::connection()->enableQueryLog();
+
+        for ($i = 0; $i < 10; ++$i) {
+            $configuration->getGenerations();
+            $configuration->getLayout();
+            $configuration->getHideSpouses();
+            $configuration->getMarriedNamesMode();
+            $configuration->getShowNicknames();
+        }
+
+        $queries = DB::connection()->getQueryLog();
+        DB::connection()->disableQueryLog();
+
+        self::assertLessThanOrEqual(
+            6,
+            count($queries),
+            'preference lookups are not memoised — the query count scales with the number of nodes'
+        );
+    }
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -179,4 +179,35 @@ final class ConfigurationTest extends TestCase
 
         self::assertSame(Configuration::MARRIED_NAMES_BIRTH_AND_MARRIED, $configuration->getMarriedNamesMode());
     }
+
+    /**
+     * The re-centering URL is rebuilt from these parameters. Every setting the
+     * data facade reads while building node data has to appear here, otherwise
+     * clicking a person silently resets it to the module preference default.
+     */
+    #[Test]
+    public function routeToggleParamsCarryEverySettingTheFacadeReads(): void
+    {
+        $configuration = $this->buildConfiguration(
+            [
+                'generations'      => '5',
+                'layout'           => Configuration::LAYOUT_TOPBOTTOM,
+                'hideSpouses'      => '1',
+                'marriedNamesMode' => Configuration::MARRIED_NAMES_ONLY,
+                'showNicknames'    => '1',
+            ],
+            []
+        );
+
+        self::assertSame(
+            [
+                'generations'      => 5,
+                'layout'           => Configuration::LAYOUT_TOPBOTTOM,
+                'hideSpouses'      => '1',
+                'marriedNamesMode' => Configuration::MARRIED_NAMES_ONLY,
+                'showNicknames'    => '1',
+            ],
+            $configuration->getRouteToggleParams()
+        );
+    }
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -274,35 +274,72 @@ final class ConfigurationTest extends TestCase
         );
     }
 
+    /**
+     * Pins the per-request query cost: however often the getters are called
+     * while the tree is built, each preference is read at most once.
+     */
     #[Test]
-    public function readsEachPreferenceAtMostOncePerRequest(): void
+    public function readsEachPreferenceOnceHoweverOftenTheGettersAreCalled(): void
+    {
+        // Compares one round against ten rather than asserting a fixed number.
+        // A fixed bound would encode today's preference count — getMarriedNamesMode()
+        // reads two, so it is six — and would fail on an unrelated future addition
+        // while blaming memoisation. It would also pass vacuously if the getters
+        // stopped querying at all. Constant cost is the property that matters.
+        $oneRound  = $this->countPreferenceQueries(1);
+        $tenRounds = $this->countPreferenceQueries(10);
+
+        self::assertGreaterThan(0, $oneRound, 'the first round must actually read the preferences');
+        self::assertSame(
+            $oneRound,
+            $tenRounds,
+            'preference lookups are not memoised — the query cost scales with the number of nodes'
+        );
+    }
+
+    /**
+     * Runs the per-node getters $rounds times against a FRESH configuration and
+     * returns how many `module_setting` queries that produced. The instance has
+     * to be fresh per measurement — reusing one would leave it memoised from the
+     * previous round and report zero.
+     */
+    private function countPreferenceQueries(int $rounds): int
     {
         $configuration = $this->buildConfiguration([], []);
+        $connection    = DB::connection();
+        $connection->flushQueryLog();
+        $connection->enableQueryLog();
 
-        // Every getter here is called once per node while the tree is built, and
-        // AbstractModule::getPreference() runs a `module_setting` query on every
-        // call — it holds no cache of its own. Without memoisation the query
-        // count therefore grows with the size of the chart. Ten rounds stand in
-        // for ten nodes: unmemoised that is 40+ queries, memoised it is at most
-        // one per distinct preference.
-        DB::connection()->flushQueryLog();
-        DB::connection()->enableQueryLog();
+        try {
+            for ($i = 0; $i < $rounds; ++$i) {
+                $configuration->getGenerations();
+                $configuration->getLayout();
+                $configuration->getHideSpouses();
+                $configuration->getMarriedNamesMode();
+                $configuration->getShowNicknames();
+            }
 
-        for ($i = 0; $i < 10; ++$i) {
-            $configuration->getGenerations();
-            $configuration->getLayout();
-            $configuration->getHideSpouses();
-            $configuration->getMarriedNamesMode();
-            $configuration->getShowNicknames();
+            // Counts only the preference reads the assertion talks about, so an
+            // unrelated query inside the window cannot change the verdict.
+            return count(array_filter($connection->getQueryLog(), $this->isPreferenceQuery(...)));
+        } finally {
+            $connection->disableQueryLog();
+            $connection->flushQueryLog();
         }
+    }
 
-        $queries = DB::connection()->getQueryLog();
-        DB::connection()->disableQueryLog();
-
-        self::assertLessThanOrEqual(
-            6,
-            count($queries),
-            'preference lookups are not memoised — the query count scales with the number of nodes'
-        );
+    /**
+     * Whether a query-log entry is a preference read.
+     *
+     * Declared as a named method with the log entry's shape rather than an
+     * inline closure: without the shape Rector wants a `(string)` cast on the
+     * query and PHPStan rejects that same cast as useless, so the two gates
+     * contradict each other.
+     *
+     * @param array{query: string, bindings: array<mixed>, time: float|null} $entry
+     */
+    private function isPreferenceQuery(array $entry): bool
+    {
+        return str_contains($entry['query'], 'module_setting');
     }
 }


### PR DESCRIPTION
Fixes #112

The update route rebuilds the node data server-side but forwarded only `generations` and `layout`. Every other setting the data facade reads while building that data fell back to the module preference default, so clicking a person to re-center silently reset it.

## Scope

Verified against what the facade actually reads, not against the full settings list:

| Setting | Read by the facade | Was forwarded |
|---|---|---|
| `generations` | yes | yes |
| `layout` | yes | yes |
| `hideSpouses` | yes | **no** |
| `marriedNamesMode` | yes | **no** |
| `showNicknames` | yes | **no** |

Spouse visibility changes the shape of the chart, so it was the most visible of the three.

`nameAbbreviation` was listed in the original issue description but is not read by the facade — name abbreviation is applied client-side and survives a re-center. That was corrected before this change.

## Approach

`getRouteToggleParams()` keeps the list in one place, so a setting added to the facade later cannot be forgotten in the route.

## Tests

Extended `ConfigurationTest` with a case pinning the collected parameters. It uses the existing preference-backed harness, so the getters resolve for real and the values are covered, not just the keys.

`composer ci:test` green (PHPStan, Rector, PHPUnit 10/10, Jest 12/12, CGL, jscpd, Biome).
