### PR TITLE
Correct the documented commit convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,34 @@ Pipeline (`make release X.Y.Z`):
 
 ## PR/commit checklist
 - `composer ci:test` must pass before every commit.
-- Use Conventional Commits; include ticket IDs in titles when available (e.g. `Fixes #182`).
+- A subject starting with `GH-` must match `^GH-\d+: [A-ZÄÖÜ]`; every other subject
+  must match `^[A-ZÄÖÜ]` — a capitalised imperative either way. The patterns check
+  only the leading capital; two starts are banned whatever their case:
+  **conventional-commit prefixes** (`feat:`, `Fix:`, `chore:` …) and path-like starts
+  (`src/Module.php: …`, `Src/Module.php: …`).
+    - The two patterns are deliberately kept separate: `^(GH-\d+: )?[A-ZÄÖÜ]` (wrong)
+      stops enforcing the capital *after* the prefix, because the optional group can
+      be skipped and the `G` of `GH-` then satisfies `[A-ZÄÖÜ]` on its own —
+      `GH-12: fix typo` would pass. Keying on the subject rather than on the branch
+      also keeps this check decidable for commits already on `main`, where the issue
+      branch no longer exists.
+    - The same two patterns apply to the **pull-request title**, which under
+      squash-merge is the subject that reaches `main`.
+    - The normative definition lives in
+      `magicsunday/.github/.github/workflows/commit-convention.yml@main`, which
+      self-tests a decision table before applying it. No workflow here calls that
+      gate, so the rule in this repository is documentation only; wherever it is
+      wired, the workflow is authoritative and this text is what gets fixed.
+- Branches for an issue are named exactly `GH-<N>`, where `<N>` is the issue number.
+  The `GH-<N>: ` prefix marks work that belongs to the issue — a commit on that
+  branch whose concern is something else (a drive-by lint fix, a catalogue resync)
+  keeps its own unprefixed subject, which is what the history actually does. Merge
+  and revert commits keep the subject git generates. Not every git-written subject
+  is exempt, though: `fixup!` and `squash!` start lowercase and violate the rule, so
+  autosquash them before opening the PR.
+- The PR body closes the issue with a `Closes #<N>` keyword. The `GH-<N>: ` subject
+  prefix is not a GitHub link and closes nothing.
+- Never add a `Co-Authored-By:` trailer or any other AI attribution.
 - Keep PRs small and focused (~≤300 net LOC) with atomic commits.
 - Ensure coverage ≥90% on touched PHP paths.
 - After PR receives review comments: assess, fix, commit, reply with commit hash, resolve threads via GraphQL.


### PR DESCRIPTION
`AGENTS.md` prescribed Conventional Commits. This repository has never used them.

Of the last 60 commits: **0** carry a conventional prefix, **60** start with a capitalised imperative. An agent following the documented rule would have produced the one format the repository does not use. The line came from a shared house template and is identical in the fan-chart and pedigree-chart modules, which are being corrected alongside this one.

Replaced with the convention actually in force:

- subjects match `^(GH-<N>: )?[A-ZÄÖÜ]` — capitalised imperative, `GH-<N>: ` prefix for issue-tied work;
- no conventional-commit prefixes, no lowercase or path-like starts;
- issue branches named exactly `GH-<N>`;
- no `Co-Authored-By:` trailer or other AI attribution.

Documentation only.