### PR TITLE
Make the type annotations survive TypeScript 7

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -13,7 +13,6 @@
         "lib": ["ES2022", "DOM"],
         "types": ["jest"],
         "ignoreDeprecations": "6.0",
-        "baseUrl": ".",
         "paths": {
             "resources/js/modules/*": ["./resources/js/modules/*"]
         }

--- a/resources/js/modules/chart.js
+++ b/resources/js/modules/chart.js
@@ -36,7 +36,7 @@ export default class Chart {
         this._configuration = configuration;
         this._parent = parent;
         this._hierarchy = new Hierarchy(this._configuration);
-        /** @type {Data|null} */
+        /** @type {CoupleNode|null} */
         this._data = null;
         /** @type {Svg} */
         this._svg = /** @type {Svg} */ (/** @type {unknown} */ (null));
@@ -65,7 +65,7 @@ export default class Chart {
     /**
      * Returns the chart data.
      *
-     * @returns {Data|null}
+     * @returns {CoupleNode|null}
      */
     get data() {
         return this._data;
@@ -74,7 +74,7 @@ export default class Chart {
     /**
      * Sets the chart data.
      *
-     * @param {Data} value The chart data
+     * @param {CoupleNode} value The chart data
      */
     set data(value) {
         this._data = value;
@@ -189,7 +189,7 @@ export default class Chart {
      * Method triggers either the "update" or "individual" method on the click
      * on a person.
      *
-     * @param {object} data The D3 data object
+     * @param {PersonBoxData} data The person payload bound to the clicked box
      *
      * @private
      */

--- a/resources/js/modules/data.js
+++ b/resources/js/modules/data.js
@@ -16,14 +16,25 @@
 /**
  * The plain person data emitted by the PHP DataFacade.
  *
+ * Mirrors `NodeData::jsonSerialize()` one-to-one: every key is always present.
+ * A placeholder node (a couple slot with no known individual) is built from a
+ * default-constructed `NodeData`, so it carries the same keys with their PHP
+ * type defaults — `xref`, `name`, `birth`, … as empty strings, `firstNames` and
+ * `lastNames` as empty arrays, `sex` as `"U"`. Consumers therefore detect a
+ * placeholder by an empty `xref`, never by a missing property.
+ *
  * @typedef {object} Data
  * @property {number}   id              The unique ID of the person
- * @property {string}   xref            The unique identifier of the person
+ * @property {string}   xref            The unique identifier of the person (empty for a placeholder)
+ * @property {string}   url             The URL of the individual's webtrees page
+ * @property {string}   updateUrl       The URL used to re-root the chart on this individual
+ * @property {number}   generation      The generation the individual belongs to (1 = chart subject)
  * @property {string}   sex             The sex of the person
  * @property {string}   birth           The birthdate of the person
  * @property {string}   death           The death date of the person
  * @property {string}   timespan        The lifetime description
  * @property {string}   thumbnail       The URL of the thumbnail image
+ * @property {string}   silhouette      The URL of the sex-specific silhouette used as onerror fallback
  * @property {string}   name            The full name of the individual
  * @property {string}   preferredName   The preferred first name
  * @property {string[]} firstNames      The list of first names
@@ -35,42 +46,71 @@
  */
 
 /**
- * A person object.
+ * One child branch of a couple node, as emitted by `CoupleNode::jsonSerialize()`.
  *
- * @typedef {object} Person
- * @property {null|Data}          data     The data object of the individual
- * @property {undefined|Number[]} spouses  The list of assigned spouse IDs (not available if "spouse" is set)
- * @property {undefined|Object[]} children The list of children of this individual
- * @property {undefined|Number}   family   The family index (0 = first family, 1 = second, ...)
- * @property {undefined|Number}   spouse   The unique ID of the direct spouse of this individual
+ * @typedef {object} CoupleFamily
+ * @property {number}       family      The family index (0 = first family, 1 = second, ...)
+ * @property {number|null}  spouseIndex The index into `CoupleNode.members` of the spouse of this
+ *                                      branch, or `null` when the branch has no recorded partner
+ * @property {CoupleNode[]} children    The descendant couple nodes of this family
  */
 
 /**
- * An individual. Extends the D3 Node object.
+ * The wire-format tree emitted by the PHP DataFacade. `members[0]` is always the
+ * "real" person; later entries are that person's spouses in registration order.
  *
- * @typedef {Node} Individual
- * @property {Person}       data     The individual data
- * @property {Individual[]} children The children of the node
- * @property {number}       x        The X-coordinate of the node
- * @property {number}       y        The Y-coordinate of the node
+ * @typedef {object} CoupleNode
+ * @property {Data[]}         members        The real person followed by their spouses
+ * @property {CoupleFamily[]} memberFamilies The per-family child branches
  */
 
 /**
- * An X/Y coordinate.
+ * One renderable family-node of the client-side tree built by `family-tree.js`.
+ * A polygamous individual contributes several of these sharing the same `real`
+ * reference; only the first carries `realFirst: true`.
  *
- * @typedef {object} Coordinate
- * @property {number} x The X-coordinate
- * @property {number} y The Y-coordinate
+ * @typedef {object} FamilyNode
+ * @property {"family"}     kind      Discriminator of the family-tree node union
+ * @property {Data}         real      The real person of this couple
+ * @property {Data|null}    spouse    The spouse of this family, or `null` when unknown
+ * @property {number}       family    The family index (0 = first family, 1 = second, ...)
+ * @property {boolean}      realFirst Whether this node renders the real-person box
+ * @property {FamilyNode[]} children  The descendant family-nodes
  */
 
 /**
- * A link between two nodes.
+ * Layout-only root that holds the chart subject's families when there is more
+ * than one. The renderer skips it.
  *
- * @typedef {object} Link
- * @property {Individual}                source The source individual
- * @property {null|Individual}           target The target individual
- * @property {null|undefined|Individual} spouse The spouse of the source individual
- * @property {null|Coordinate[]}         coords The list of the spouse coordinates
+ * @typedef {object} PseudoRootNode
+ * @property {"pseudo-root"} kind     Discriminator of the family-tree node union
+ * @property {FamilyNode[]}  children The chart subject's families
+ */
+
+/**
+ * Any node of the client-side family tree fed into `d3.hierarchy()`.
+ *
+ * @typedef {FamilyNode|PseudoRootNode} FamilyTreeNode
+ */
+
+/**
+ * The person payload bound to a rendered box. The `spouse` flag drives the
+ * `.spouse` CSS class and the double `data.data` access in the drawers.
+ *
+ * @typedef {object} PersonBoxData
+ * @property {Data}    data   The person data
+ * @property {boolean} spouse Whether this box renders a spouse rather than the real person
+ */
+
+/**
+ * A positioned person box produced by `connection-builder.js` and bound as the
+ * d3 datum of a `g.person` element.
+ *
+ * @typedef {object} RenderedBox
+ * @property {string}        id   The d3 join key, `"<hierarchy node id>-<member index>"`
+ * @property {number}        x    The X-coordinate of the box centre
+ * @property {number}        y    The Y-coordinate of the box centre
+ * @property {PersonBoxData} data The person payload of the box
  */
 
 /**
@@ -79,10 +119,24 @@
  * d3-hierarchy wrapping of the FamilyNode plus the person payload.
  *
  * @typedef {object} NameElementData
- * @property {{data: Data, spouse: boolean}} data
+ * @property {PersonBoxData} data
  * @property {boolean} [isRtl]
  * @property {boolean} [isAltRtl]
  * @property {boolean} [withImage]
+ */
+
+/**
+ * One date row bound to a `text.date` element by `tree/date.js`. Vertical
+ * layouts render a single lifetime row (`label` + `withImage`); horizontal
+ * layouts render a birth and/or death row that additionally carries the marker
+ * icon and the corresponding flag.
+ *
+ * @typedef {object} DateElementData
+ * @property {string}  label     The formatted date text
+ * @property {boolean} withImage Whether a highlight image takes up part of the box width
+ * @property {string}  [icon]    The birth (★) or death (†) marker, horizontal layouts only
+ * @property {boolean} [birth]   Whether this row holds the birthdate
+ * @property {boolean} [death]   Whether this row holds the death date
  */
 
 /**

--- a/resources/js/modules/family-tree.js
+++ b/resources/js/modules/family-tree.js
@@ -21,9 +21,9 @@
  * - many families ⇒ a `pseudo-root` node holds them as children. Pseudo-roots
  *   are layout-only; the renderer skips them.
  *
- * @param {object} coupleData
+ * @param {CoupleNode} coupleData The wire-format couple tree emitted by the PHP DataFacade
  *
- * @returns {object}
+ * @returns {FamilyTreeNode}
  */
 export function buildFamilyTree(coupleData) {
     const families = coupleToFamilies(coupleData);
@@ -36,6 +36,13 @@ export function buildFamilyTree(coupleData) {
     };
 }
 
+/**
+ * Converts one wire-format couple node into the family-nodes it contributes.
+ *
+ * @param {CoupleNode} coupleData The couple node to convert
+ *
+ * @returns {FamilyNode[]}
+ */
 function coupleToFamilies(coupleData) {
     if (!coupleData || !Array.isArray(coupleData.members) || coupleData.members.length === 0) {
         return [];
@@ -85,9 +92,9 @@ function coupleToFamilies(coupleData) {
  * both real and spouse boxes spans `2 × box + spouseGap`; a spouse-only family
  * or a singleton spans one box.
  *
- * @param {object} familyData
- * @param {number} boxSize
- * @param {number} spouseGap
+ * @param {FamilyTreeNode} familyData The family-tree node to measure
+ * @param {number}         boxSize    The box extent along the spread axis
+ * @param {number}         spouseGap  The gap between the real-person and spouse box
  *
  * @returns {number}
  */
@@ -108,9 +115,9 @@ export function familyRenderedWidth(familyData, boxSize, spouseGap) {
  * this family-node should render, ordered left-to-right (vertical layout) or
  * top-to-bottom (horizontal layout).
  *
- * @param {object} familyData
+ * @param {FamilyTreeNode} familyData The family-tree node to render
  *
- * @returns {Array<{data: object, isReal: boolean}>}
+ * @returns {Array<{data: Data, isReal: boolean}>}
  */
 export function familyRenderableMembers(familyData) {
     if (familyData?.kind !== "family") {

--- a/resources/js/modules/hierarchy.js
+++ b/resources/js/modules/hierarchy.js
@@ -41,7 +41,7 @@ export default class Hierarchy {
      * individuals contribute multiple FamilyNodes that share the same `real`.
      * d3.tree() then centres each family-node directly over its own children.
      *
-     * @param {object} data The JSON encoded chart data
+     * @param {CoupleNode} data The JSON encoded chart data
      */
     init(data) {
         // Adjust box height if we are going to display the alternative names

--- a/resources/js/modules/index.js
+++ b/resources/js/modules/index.js
@@ -28,14 +28,14 @@ export class DescendantsChart {
      * @param {object} options  A list of options passed from outside to the application
      *
      * @param {{zoom: string, move: string}} options.labels
-     * @param {boolean}  options.rtl
-     * @param {number}   options.generations
-     * @param {string}   options.treeLayout
-     * @param {boolean}  options.openNewTabOnClick
-     * @param {boolean}  options.showAlternativeName
-     * @param {string}   options.nameAbbreviation
-     * @param {string[]} options.cssFiles
-     * @param {Data[]}   options.data
+     * @param {boolean}    options.rtl
+     * @param {number}     options.generations
+     * @param {string}     options.treeLayout
+     * @param {boolean}    options.openNewTabOnClick
+     * @param {boolean}    options.showAlternativeName
+     * @param {string}     options.nameAbbreviation
+     * @param {string[]}   options.cssFiles
+     * @param {CoupleNode} options.data
      */
     constructor(selector, options) {
         this._selector = selector;
@@ -122,7 +122,7 @@ export class DescendantsChart {
     /**
      * Draws the chart.
      *
-     * @param {object} data The JSON encoded chart data
+     * @param {CoupleNode} data The JSON encoded chart data
      */
     draw(data) {
         this._chart.data = data;

--- a/resources/js/modules/tree/connection-builder.js
+++ b/resources/js/modules/tree/connection-builder.js
@@ -31,7 +31,7 @@ import { familyRenderableMembers } from "../family-tree.js";
  * @param {Orientation}        orientation      The active orientation
  * @param {boolean}            isVerticalLayout True for top-bottom / bottom-top
  *
- * @returns {{renderedBoxes: Array, connections: Array}}
+ * @returns {{renderedBoxes: RenderedBox[], connections: Array}}
  */
 export function buildConnections(root, orientation, isVerticalLayout) {
     const stackBox = isVerticalLayout ? orientation.boxWidth : orientation.boxHeight;

--- a/resources/js/modules/tree/date.js
+++ b/resources/js/modules/tree/date.js
@@ -153,9 +153,9 @@ export default class DateRenderer {
     /**
      * Truncates a date value.
      *
-     * @param {object} object         The D3 object containing the text value
-     * @param {string} date           The date value to truncate
-     * @param {number} availableWidth The total available width the text could take
+     * @param {Selection<any, any, any, any>} object         The D3 element containing the text value
+     * @param {string}                        date           The date value to truncate
+     * @param {number}                        availableWidth The total available width the text could take
      *
      * @returns {string}
      *
@@ -185,8 +185,10 @@ export default class DateRenderer {
     }
 
     /**
+     * Returns the X-coordinate of a date row, shifted by the image width when
+     * a highlight image is displayed.
      *
-     * @param {object} d
+     * @param {DateElementData} d The date row descriptor
      *
      * @returns {number}
      *
@@ -203,9 +205,9 @@ export default class DateRenderer {
      * Measures the given text and return its width depending on the used font
      * (including size and weight).
      *
-     * @param {string} text
-     * @param {string} fontSize
-     * @param {number} fontWeight
+     * @param {string}        text
+     * @param {string}        fontSize
+     * @param {string|number} fontWeight
      *
      * @returns {number}
      *

--- a/resources/js/modules/tree/name.js
+++ b/resources/js/modules/tree/name.js
@@ -354,9 +354,9 @@ export default class Name {
     /**
      * Creates the data array for the names.
      *
-     * @param {object}             parent
-     * @param {LabelElementData[]} names
-     * @param {number}             availableWidth
+     * @param {Selection<any, any, any, any>} parent
+     * @param {LabelElementData[]}            names
+     * @param {number}                        availableWidth
      *
      * @returns {LabelElementData[]}
      *
@@ -412,8 +412,10 @@ export default class Name {
     }
 
     /**
+     * Returns the X-coordinate of a name element, shifted by the image width
+     * when a highlight image is displayed.
      *
-     * @param {object} d
+     * @param {NameElementData} d The name element descriptor
      *
      * @returns {number}
      *
@@ -430,9 +432,9 @@ export default class Name {
      * Measures the given text and return its width depending on the used font
      * (including size and weight).
      *
-     * @param {string} text
-     * @param {string} fontSize
-     * @param {number} fontWeight
+     * @param {string}        text
+     * @param {string}        fontSize
+     * @param {string|number} fontWeight
      *
      * @returns {number}
      *

--- a/resources/js/modules/tree/node-drawer.js
+++ b/resources/js/modules/tree/node-drawer.js
@@ -12,6 +12,7 @@ import ImageBox from "../chart/box/image.js";
 import TextBox from "../chart/box/text.js";
 
 /**
+ * @import { HierarchyNode } from "d3-hierarchy"
  * @import { Selection } from "d3-selection"
  * @import Svg from "../chart/svg.js"
  * @import Hierarchy from "../hierarchy.js"
@@ -48,8 +49,8 @@ export default class NodeDrawer {
     /**
      * Draw the person boxes.
      *
-     * @param {Array} renderedBoxes Pre-positioned box descriptors from connection-builder
-     * @param {object} source       The root object
+     * @param {RenderedBox[]}                 renderedBoxes Pre-positioned box descriptors from connection-builder
+     * @param {HierarchyNode<FamilyTreeNode>} source        The node the enter/exit transitions originate from
      *
      * @public
      */
@@ -87,8 +88,8 @@ export default class NodeDrawer {
     /**
      * Enter transition (new nodes).
      *
-     * @param {Selection<any, any, any, any>}  enter
-     * @param {Individual} _source
+     * @param {Selection<any, any, any, any>} enter
+     * @param {HierarchyNode<FamilyTreeNode>} _source
      *
      * @private
      */
@@ -149,7 +150,7 @@ export default class NodeDrawer {
      * Exit transition (nodes to be removed).
      *
      * @param {Selection<any, any, any, any>} exit
-     * @param {Individual}                    source
+     * @param {HierarchyNode<FamilyTreeNode>} source
      *
      * @private
      */

--- a/resources/views/modules/descendants-chart/chart.phtml
+++ b/resources/views/modules/descendants-chart/chart.phtml
@@ -15,10 +15,10 @@ use MagicSunday\Webtrees\DescendantsChart\Configuration;
 /**
  * @var string        $javascript
  * @var Configuration $configuration
- * @var array         $id                The unique chart ID
+ * @var string        $id                The unique chart ID
  * @var array         $chartParams
  * @var string[]      $exportStylesheets A list of stylesheets used by SVG export
- * @var array         $data              The chart data
+ * @var array|null    $data              The chart data tree, JSON-serialized into the chart "data" option
  */
 ?>
 


### PR DESCRIPTION
Preventive. Nothing is broken here today — the `typescript` pin is still `^6.0.3`. But the sibling `webtrees-fan-chart` has already taken the `^7.0.2` bump and went red on it, and this repository carries the identical exposure.

## Why removing baseUrl alone would not have been enough

TypeScript 7 removed the `baseUrl` compiler option **and** tightened property access on the `object` type. The first alone aborts `tsc` before it reports anything else. Dropping `baseUrl` here uncovers **22 follow-up errors** that were never visible, plus 2 more that only appear once the selection parameters are properly typed — the same masking that made the fan-chart breakage look like a one-line fix.

Fixing them now means the eventual Dependabot bump is a green PR instead of a red one.

## Scope

- `baseUrl` removed; the `paths` values are already config-relative and resolve unchanged without it (supported since TypeScript 4.1).
- `Data` gains the four keys it was missing from `NodeData::jsonSerialize()`. Every key is required: a placeholder slot ships a default-constructed `NodeData`, so it carries the same keys with PHP type defaults rather than omitting them. Consumers detect placeholders via an empty `xref`, and the typedef now says so.
- Four typedefs describing shapes the code no longer produces are removed. Keeping them beside the new ones would have been the same parallel duplication they were left over from.
- **The pin itself is deliberately left alone.** TypeScript 7 was installed only as a local oracle and reverted; `package.json` and `package-lock.json` are untouched.

## Two documentation bugs the bare `object` had been hiding

- `@typedef {Node} Individual` silently resolved to the **DOM** `Node` interface, so nodes were documented as DOM elements while actually receiving a d3 `HierarchyNode`.
- `measureText()` `fontWeight` receives a CSS string, not a number.

Neither was a runtime fault — every call site was already correct.

## Verification

`tsc` 0 errors under **both** TypeScript 6.0.3 and 7.0.2; `composer ci:test` `rc=0`; 12 tests green; `git diff` on `package.json` / `package-lock.json` empty. No executable line changed — the only non-comment edit in the whole JS diff is the deleted `baseUrl`.

The view template docblock is corrected in a separate commit: it declared `$id` and `$data` as arrays, while `Module.php` assigns `uniqid()` and an `?array`.

One finding from review was deliberately **not** folded in, because it needs a browser check and has its own scope: #117 (unfinished baseline attribute migration).