### PR TITLE
Fix unlink-base deleting an unrestorable module-base

### DIFF
--- a/Make/dev.mk
+++ b/Make/dev.mk
@@ -18,8 +18,8 @@ link-base: .logo ## Symlink .build/vendor/.../webtrees-module-base to the siblin
 		echo -e "${FRED} ✘${FRESET} Expected sibling clone at $(MODULE_BASE_CLONE)"; \
 		exit 1; \
 	fi
-	@rm -rf $(MODULE_BASE_VENDOR)
-	@ln -s "$$(cd $(MODULE_BASE_CLONE) && pwd)" $(MODULE_BASE_VENDOR)
+	@rm -rf "$(MODULE_BASE_VENDOR)"
+	@ln -s "$$(cd $(MODULE_BASE_CLONE) && pwd)" "$(MODULE_BASE_VENDOR)"
 	@echo -e "${FGREEN} ✔${FRESET} Symlinked $(MODULE_BASE_VENDOR) → $$(cd $(MODULE_BASE_CLONE) && pwd)"
 	@echo -e "${FYELLOW}   Note:${FRESET} composer install/update will replace this symlink with a fresh checkout."
 

--- a/Make/dev.mk
+++ b/Make/dev.mk
@@ -23,7 +23,16 @@ link-base: .logo ## Symlink .build/vendor/.../webtrees-module-base to the siblin
 	@echo -e "${FGREEN} ✔${FRESET} Symlinked $(MODULE_BASE_VENDOR) → $$(cd $(MODULE_BASE_CLONE) && pwd)"
 	@echo -e "${FYELLOW}   Note:${FRESET} composer install/update will replace this symlink with a fresh checkout."
 
-unlink-base: .logo ## Restore .build/vendor/.../webtrees-module-base from composer.
-	@rm -rf $(MODULE_BASE_VENDOR)
-	@$(COMPOSE_RUN) composer install --quiet
-	@echo -e "${FGREEN} ✔${FRESET} Restored $(MODULE_BASE_VENDOR) from composer."
+unlink-base: .logo ## Remove the module-base dev symlink; print how to restore the composer checkout.
+	@if [ ! -L "$(MODULE_BASE_VENDOR)" ]; then \
+		if [ -e "$(MODULE_BASE_VENDOR)" ]; then \
+			echo -e "${FYELLOW} ⚠${FRESET} $(MODULE_BASE_VENDOR) is a real checkout, not a symlink — leaving it untouched."; \
+		else \
+			echo -e "${FYELLOW} ⚠${FRESET} $(MODULE_BASE_VENDOR) does not exist — nothing to unlink."; \
+		fi; \
+	else \
+		rm -f "$(MODULE_BASE_VENDOR)"; \
+		echo -e "${FGREEN} ✔${FRESET} Removed the dev symlink $(MODULE_BASE_VENDOR)."; \
+		echo -e "${FYELLOW}   Restore the composer checkout by running composer install for this module"; \
+		echo -e "   through the webtrees buildbox (these repos ship no PHP/composer container of their own).${FRESET}"; \
+	fi

--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Nejprve zkrátit křestní jména"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Nejprve zkrátit příjmení"
 
@@ -32,7 +32,7 @@ msgstr "Nejprve zkrátit příjmení"
 msgid "An overview of an individual’s descendants."
 msgstr "Přehled potomků osoby."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automaticky (podle tradice příjmení stromu)"
 
@@ -40,11 +40,11 @@ msgstr "Automaticky (podle tradice příjmení stromu)"
 msgid "Behavior"
 msgstr "Chování"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Pouze rodné jméno"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Rodné jméno se jménem po sňatku v závorkách"
 
@@ -132,7 +132,7 @@ msgstr ""
 "Martin \"Chalky\" White). Napodobuje původní chování webtrees pro stromy, "
 "které přezdívky ukládají do samostatného pole GEDCOM NICK."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Pouze jméno po sňatku"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "zrušit"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "dolů"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "vlevo"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "vpravo"
 
@@ -231,7 +231,7 @@ msgstr "vpravo"
 msgid "save"
 msgstr "uložit"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "nahoru"
 

--- a/resources/lang/da/messages.po
+++ b/resources/lang/da/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavne først"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Forkort efternavne først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort efternavne først"
 msgid "An overview of an individual’s descendants."
 msgstr "En oversigt over en persons efterkommere."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (baseret på træets efternavnstradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (baseret på træets efternavnstradition)"
 msgid "Behavior"
 msgstr "Adfærd"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Kun fødselsnavn"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Fødselsnavn med gifteenavn i parentes"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(f.eks. Martin \"Chalky\" White). Efterligner den tidligere webtrees-adfærd "
 "for træer, der gemmer kælenavne i det separate GEDCOM NICK-felt."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Kun gifteenavn"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "fortryd"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "højre"
 
@@ -231,7 +231,7 @@ msgstr "højre"
 msgid "save"
 msgstr "gem"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "op"
 

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Zuerst Vornamen abkürzen"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Zuerst Nachnamen abkürzen"
 
@@ -32,7 +32,7 @@ msgstr "Zuerst Nachnamen abkürzen"
 msgid "An overview of an individual’s descendants."
 msgstr "Ein Überblick über die Nachkommen einer Person."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 msgid "Behavior"
 msgstr "Verhalten"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Nur Geburtsname"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Geburtsname mit Ehenamen in Klammern"
 
@@ -136,7 +136,7 @@ msgstr ""
 "Verhalten für Bäume nach, die Spitznamen im separaten GEDCOM NICK-Feld "
 "speichern."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Nur Ehenamen"
 
@@ -222,15 +222,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Abbrechen"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "Unten"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "Links"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "Rechts"
 
@@ -238,7 +238,7 @@ msgstr "Rechts"
 msgid "save"
 msgstr "Speichern"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "Oben"
 

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Abbreviate given names first"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Abbreviate surnames first"
 
@@ -32,7 +32,7 @@ msgstr "Abbreviate surnames first"
 msgid "An overview of an individual’s descendants."
 msgstr "An overview of an individual’s descendants."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatic (based on tree's surname tradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatic (based on tree's surname tradition)"
 msgid "Behavior"
 msgstr "Behavior"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Birth name only"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Birth name with married name in brackets"
 
@@ -132,7 +132,7 @@ msgstr ""
 "surname (e.g. Martin \"Chalky\" White). Mirrors the legacy webtrees "
 "behaviour for trees that store nicknames in the separate GEDCOM NICK field."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Married name only"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "cancel"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "down"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "left"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "right"
 
@@ -231,7 +231,7 @@ msgstr "right"
 msgid "save"
 msgstr "save"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "up"
 

--- a/resources/lang/es/messages.po
+++ b/resources/lang/es/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Abreviar primero los nombres de pila"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Abreviar primero los apellidos"
 
@@ -32,7 +32,7 @@ msgstr "Abreviar primero los apellidos"
 msgid "An overview of an individual’s descendants."
 msgstr "Vista individual de descendientes."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automático (según la tradición de apellidos del árbol)"
 
@@ -40,11 +40,11 @@ msgstr "Automático (según la tradición de apellidos del árbol)"
 msgid "Behavior"
 msgstr "Comportamiento"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Solo nombre de nacimiento"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Nombre de nacimiento con nombre de casada entre paréntesis"
 
@@ -134,7 +134,7 @@ msgstr ""
 "webtrees para árboles que guardan los apodos en el campo GEDCOM NICK "
 "separado."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Solo nombre de casada"
 
@@ -218,15 +218,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Cancelar"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "abajo"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "izquierda"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "derecha"
 
@@ -234,7 +234,7 @@ msgstr "derecha"
 msgid "save"
 msgstr "guardar"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "arriba"
 

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Abréger d'abord les prénoms"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Abréger d'abord les noms de famille"
 
@@ -32,7 +32,7 @@ msgstr "Abréger d'abord les noms de famille"
 msgid "An overview of an individual’s descendants."
 msgstr "Un aperçu des descendants d’un individu."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 
@@ -40,11 +40,11 @@ msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 msgid "Behavior"
 msgstr "Comportement"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Nom de naissance uniquement"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Nom de naissance avec nom d'épouse entre parenthèses"
 
@@ -134,7 +134,7 @@ msgstr ""
 "de webtrees pour les arbres qui stockent les surnoms dans le champ GEDCOM "
 "NICK séparé."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Nom d'épouse uniquement"
 
@@ -218,15 +218,15 @@ msgstr ""
 msgid "cancel"
 msgstr "annuler"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "bas"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "gauche"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "droite"
 
@@ -234,7 +234,7 @@ msgstr "droite"
 msgid "save"
 msgstr "enregistrer"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "haut"
 

--- a/resources/lang/is/messages.po
+++ b/resources/lang/is/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Stytta eiginnöfn fyrst"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Stytta eftirnöfn fyrst"
 
@@ -32,7 +32,7 @@ msgstr "Stytta eftirnöfn fyrst"
 msgid "An overview of an individual’s descendants."
 msgstr "Yfirlit yfir afkomendur einstaklings."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 
@@ -40,11 +40,11 @@ msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 msgid "Behavior"
 msgstr "Hegðun"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Aðeins fæðingarnafn"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Fæðingarnafn með giftingarnafni innan sviga"
 
@@ -134,7 +134,7 @@ msgstr ""
 "(t.d. Martin \"Chalky\" White). Líkir eftir gamla webtrees-hegðuninni fyrir "
 "tré sem geyma gælunöfn í sérstaka GEDCOM NICK-reitinn."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Aðeins giftingarnafn"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "hætta"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "niður"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "vinstri"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "hægri"
 
@@ -235,7 +235,7 @@ msgstr "hægri"
 msgid "save"
 msgstr "vista"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "upp"
 

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavn først"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternavn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternavn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Et diagram over en persons etterkommere."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på treets etternavnstradisjon)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (basert på treets etternavnstradisjon)"
 msgid "Behavior"
 msgstr "Atferd"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Bare fødselsnavn"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Fødselsnavn med navn som gift i parentes"
 
@@ -134,7 +134,7 @@ msgstr ""
 "(f.eks. Martin \"Chalky\" White). Gjenskaper den tidligere webtrees-"
 "oppførselen for trær som lagrer kallenavn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Bare navn som gift"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "høyre"
 
@@ -235,7 +235,7 @@ msgstr "høyre"
 msgid "save"
 msgstr "lagre"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "opp"
 

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Voornamen eerst afkorten"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Achternamen eerst afkorten"
 
@@ -32,7 +32,7 @@ msgstr "Achternamen eerst afkorten"
 msgid "An overview of an individual’s descendants."
 msgstr "Een overzicht van de afstammelingen van een persoon."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 msgid "Behavior"
 msgstr "Gedrag"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Alleen geboortenaam"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Geboortenaam met huwelijksnaam tussen haakjes"
 
@@ -136,7 +136,7 @@ msgstr ""
 "gedrag na voor stambomen die bijnamen in het afzonderlijke GEDCOM NICK-veld "
 "opslaan."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Alleen huwelijksnaam"
 
@@ -220,15 +220,15 @@ msgstr ""
 msgid "cancel"
 msgstr "annuleren"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "omlaag"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "links"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "rechts"
 
@@ -236,7 +236,7 @@ msgstr "rechts"
 msgid "save"
 msgstr "opslaan"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "omhoog"
 

--- a/resources/lang/nn/messages.po
+++ b/resources/lang/nn/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Forkort førenamn først"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternamn først"
 
@@ -32,7 +32,7 @@ msgstr "Forkort etternamn først"
 msgid "An overview of an individual’s descendants."
 msgstr "Eit diagram som syner ein person sine etterkomarar."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 
@@ -40,11 +40,11 @@ msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 msgid "Behavior"
 msgstr "Åtferd"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Berre fødenamn"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Fødenamn med namn som gift i parentes"
 
@@ -134,7 +134,7 @@ msgstr ""
 "Martin \"Chalky\" White). Tek att den gamle webtrees-åtferda for tre som "
 "lagrar kallenamn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Berre namn som gift"
 
@@ -219,15 +219,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "høgre"
 
@@ -235,7 +235,7 @@ msgstr "høgre"
 msgid "save"
 msgstr "lagre"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "opp"
 

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Сокращать сначала имена"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Сокращать сначала фамилии"
 
@@ -32,7 +32,7 @@ msgstr "Сокращать сначала фамилии"
 msgid "An overview of an individual’s descendants."
 msgstr "Диаграмма потомков в виде дерева."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматически (по традиции фамилий дерева)"
 
@@ -40,11 +40,11 @@ msgstr "Автоматически (по традиции фамилий дер�
 msgid "Behavior"
 msgstr "Поведение"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Только имя при рождении"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Имя при рождении с фамилией в браке в скобках"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(например, Martin \"Chalky\" White). Повторяет прежнее поведение webtrees "
 "для деревьев, в которых прозвища хранятся в отдельном поле GEDCOM NICK."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Только фамилия в браке"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Отмена"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "вниз"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "влево"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "вправо"
 
@@ -231,7 +231,7 @@ msgstr "вправо"
 msgid "save"
 msgstr "Сохранить"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "вверх"
 

--- a/resources/lang/sl/messages.po
+++ b/resources/lang/sl/messages.po
@@ -23,11 +23,11 @@ msgstr ""
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 "X-Loco-Parser: loco_parse_po\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Najprej skrajšaj osebna imena"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Najprej skrajšaj priimke"
 
@@ -35,7 +35,7 @@ msgstr "Najprej skrajšaj priimke"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomcev osebe."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 
@@ -43,11 +43,11 @@ msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 msgid "Behavior"
 msgstr "Vedenje"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Samo rojstno ime"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Rojstno ime s poročnim priimkom v oklepaju"
 
@@ -137,7 +137,7 @@ msgstr ""
 "Martin \"Chalky\" White). Posnema staro vedenje webtrees za drevesa, ki "
 "vzdevke shranjujejo v ločenem polju GEDCOM NICK."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Samo poročni priimek"
 
@@ -222,15 +222,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Prekliči"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "Dol"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "Levo"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "Desno"
 
@@ -238,7 +238,7 @@ msgstr "Desno"
 msgid "save"
 msgstr "Shrani"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "Gor"
 

--- a/resources/lang/sr-Latn/messages.po
+++ b/resources/lang/sr-Latn/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Prvo skrati lična imena"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Prvo skrati prezimena"
 
@@ -33,7 +33,7 @@ msgstr "Prvo skrati prezimena"
 msgid "An overview of an individual’s descendants."
 msgstr "Pregled potomaka pojedinca."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 
@@ -41,11 +41,11 @@ msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 msgid "Behavior"
 msgstr "Ponašanje"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Samo rodno ime"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Rodno ime sa bračnim prezimenom u zagradi"
 
@@ -133,7 +133,7 @@ msgstr ""
 "(npr. Martin \"Chalky\" White). Oponaša staro webtrees ponašanje za stabla "
 "koja nadimke čuvaju u zasebnom polju GEDCOM NICK."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Samo bračno prezime"
 
@@ -216,15 +216,15 @@ msgstr ""
 msgid "cancel"
 msgstr "odustani"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "dole"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "levo"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "desno"
 
@@ -232,7 +232,7 @@ msgstr "desno"
 msgid "save"
 msgstr "snimi"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "gore"
 

--- a/resources/lang/sv/messages.po
+++ b/resources/lang/sv/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Förkorta förnamn först"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Förkorta efternamn först"
 
@@ -32,7 +32,7 @@ msgstr "Förkorta efternamn först"
 msgid "An overview of an individual’s descendants."
 msgstr "En översikt över en persons ättlingar."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 
@@ -40,11 +40,11 @@ msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 msgid "Behavior"
 msgstr "Beteende"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Endast födelsenamn"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Födelsenamn med giftasnamn inom parentes"
 
@@ -132,7 +132,7 @@ msgstr ""
 "(t.ex. Martin \"Chalky\" White). Återskapar det tidigare webtrees-beteendet "
 "för träd som lagrar smeknamn i det separata GEDCOM NICK-fältet."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Endast giftasnamn"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "ner"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "vänster"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "höger"
 
@@ -231,7 +231,7 @@ msgstr "höger"
 msgid "save"
 msgstr "spara"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "upp"
 

--- a/resources/lang/uk/messages.po
+++ b/resources/lang/uk/messages.po
@@ -21,11 +21,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Спершу скорочувати імена"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Спершу скорочувати прізвища"
 
@@ -33,7 +33,7 @@ msgstr "Спершу скорочувати прізвища"
 msgid "An overview of an individual’s descendants."
 msgstr "Огляд нащадків персони у вигляді дерева."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматично (за традицією прізвищ дерева)"
 
@@ -41,11 +41,11 @@ msgstr "Автоматично (за традицією прізвищ дере�
 msgid "Behavior"
 msgstr "Поведінка"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Лише ім'я при народженні"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Ім'я при народженні з прізвищем у шлюбі в дужках"
 
@@ -133,7 +133,7 @@ msgstr ""
 "Martin \"Chalky\" White). Повторює попередню поведінку webtrees для дерев, "
 "які зберігають прізвиська в окремому полі GEDCOM NICK."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Лише прізвище у шлюбі"
 
@@ -216,15 +216,15 @@ msgstr ""
 msgid "cancel"
 msgstr "скасувати"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "вниз"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "ліворуч"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "праворуч"
 
@@ -232,7 +232,7 @@ msgstr "праворуч"
 msgid "save"
 msgstr "зберегти"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "вгору"
 

--- a/resources/lang/vi/messages.po
+++ b/resources/lang/vi/messages.po
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-SearchPath-2: webtrees-descendants-chart/resources/views\n"
 "X-Poedit-SearchPath-3: webtrees-module-base/src\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "Viết tắt tên gọi trước"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "Viết tắt họ trước"
 
@@ -32,7 +32,7 @@ msgstr "Viết tắt họ trước"
 msgid "An overview of an individual’s descendants."
 msgstr "Tổng quan về con cháu của một cá nhân."
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 
@@ -40,11 +40,11 @@ msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 msgid "Behavior"
 msgstr "Hành vi"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "Chỉ tên khai sinh"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "Tên khai sinh kèm tên sau khi kết hôn trong ngoặc"
 
@@ -132,7 +132,7 @@ msgstr ""
 "Martin \"Chalky\" White). Tái hiện hành vi webtrees cũ cho cây gia phả lưu "
 "biệt danh trong trường GEDCOM NICK riêng."
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "Chỉ tên sau khi kết hôn"
 
@@ -215,15 +215,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Hủy bỏ"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "Từ trên xuống"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "Từ trái sang phải"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "Từ phải sang trái"
 
@@ -231,7 +231,7 @@ msgstr "Từ phải sang trái"
 msgid "save"
 msgstr "lưu"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "Từ dưới lên"
 

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Configuration.php:405
+#: src/Configuration.php:459
 msgid "Abbreviate given names first"
 msgstr "优先缩写名字"
 
-#: src/Configuration.php:406
+#: src/Configuration.php:460
 msgid "Abbreviate surnames first"
 msgstr "优先缩写姓氏"
 
@@ -30,7 +30,7 @@ msgstr "优先缩写姓氏"
 msgid "An overview of an individual’s descendants."
 msgstr "个人后代的概览图"
 
-#: src/Configuration.php:404
+#: src/Configuration.php:458
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "自动（根据族谱的姓氏传统）"
 
@@ -38,11 +38,11 @@ msgstr "自动（根据族谱的姓氏传统）"
 msgid "Behavior"
 msgstr "行为"
 
-#: src/Configuration.php:270
+#: src/Configuration.php:332
 msgid "Birth name only"
 msgstr "仅出生姓名"
 
-#: src/Configuration.php:272
+#: src/Configuration.php:334
 msgid "Birth name with married name in brackets"
 msgstr "出生姓名后附婚后姓名（括号内）"
 
@@ -130,7 +130,7 @@ msgstr ""
 "White）。模拟旧版 webtrees 的行为，适用于在单独的 GEDCOM NICK 字段中保存昵称"
 "的家谱。"
 
-#: src/Configuration.php:271
+#: src/Configuration.php:333
 msgid "Married name only"
 msgstr "仅婚后姓名"
 
@@ -214,15 +214,15 @@ msgstr ""
 msgid "cancel"
 msgstr "取消"
 
-#: src/Configuration.php:193 src/Configuration.php:201
+#: src/Configuration.php:252 src/Configuration.php:260
 msgid "down"
 msgstr "子孙在下"
 
-#: src/Configuration.php:190 src/Configuration.php:198
+#: src/Configuration.php:249 src/Configuration.php:257
 msgid "left"
 msgstr "子孙在左"
 
-#: src/Configuration.php:191 src/Configuration.php:199
+#: src/Configuration.php:250 src/Configuration.php:258
 msgid "right"
 msgstr "子孙在右"
 
@@ -230,7 +230,7 @@ msgstr "子孙在右"
 msgid "save"
 msgstr "保存"
 
-#: src/Configuration.php:192 src/Configuration.php:200
+#: src/Configuration.php:251 src/Configuration.php:259
 msgid "up"
 msgstr "子孙在上"
 


### PR DESCRIPTION
## The bug

`unlink-base` ran `rm -rf` on the vendored `webtrees-module-base` and then a
`composer install` that cannot run in these repos, so the restore step the target
advertises was unreliable while the delete had already happened — leaving the
module without its dependency. (The chart repos routed composer through the `node`
service, which has neither composer nor php; this one required composer on the host
PATH.)

## The fix

Guard on the symlink: only remove `MODULE_BASE_VENDOR` when it actually is a symlink
(what `link-base` creates), with `rm -f`. A real composer checkout is then left
untouched instead of deleted-and-unrestorable. The broken composer call is dropped;
the target prints how to restore through the buildbox. This unifies the four sibling
repos (`webtrees-fan-chart`, `webtrees-pedigree-chart`, `webtrees-descendants-chart`,
`webtrees-statistics`) onto one canonical, container-agnostic target — verified
byte-identical. Fixed under the `webtrees-fan-chart` tracking issue.

Verified: real checkout present → untouched; a symlink → removed, its clone target
survives; nothing present → safe no-op.

## Note

Includes a second commit that resyncs stale `#:` catalogue locations (drifted from a prior `src/Configuration.php` change without a follow-up `make lang`), which the pre-push freshness gate required before this branch could push. Location-only, MO-neutral.