### PR TITLE
Wire the shared commit-convention gate

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,30 @@
+name: Commit lint
+
+# `edited` and the concurrency group are a package, not two independent choices.
+# The gate checks the pull-request title because this repository squash-merges,
+# and the default activity types do not include title edits — without `edited` a
+# title broken after a green run is never re-judged, and a title fixed after a red
+# one has nothing to re-run. But `edited` also makes several runs fire against the
+# same head commit, and branch protection keeps whichever finishes last: a green
+# run started before a title was broken can overwrite the red one that followed.
+# Cancelling in progress removes that race, and is safe because this gate mutates
+# nothing — only the newest title is meant to be judged.
+#
+# The calling job deliberately declares no `permissions:` block of its own: a
+# job-level block would replace the top-level one rather than merge with it, so
+# leaving it off is what makes the top-level grant below the one in effect.
+on:
+    pull_request:
+        types: [opened, reopened, synchronize, edited]
+
+permissions:
+    contents: read
+    pull-requests: read
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    commit-convention:
+        uses: magicsunday/.github/.github/workflows/commit-convention.yml@main


### PR DESCRIPTION
Wires the shared commit-convention gate into this repository.

## Why

The commit-subject rule lived here as documented prose with nothing executing it, so it could only drift — which is how the same rule came to be stated in several different ways across the sibling repositories. `magicsunday/.github/.github/workflows/commit-convention.yml` already holds the normative definition **and self-tests its own decision table on every run**, so calling it makes the rule enforced rather than merely written down.

## What

One workflow file, byte-identical to the caller `webtrees-fan-chart` already uses. Nothing repo-specific.

- The calling job declares no `permissions:` of its own on purpose: a job-level block would *replace* the top-level grant rather than merge with it, so leaving it off is what keeps `contents: read` + `pull-requests: read` in effect for the reusable workflow.
- `edited` and the concurrency group are a package: the gate judges the pull-request title, and without `edited` a title broken after a green run would never be re-judged; `cancel-in-progress` then removes the race where an older green run overwrites a newer red one.

## Note

The check is **advisory** until the context `commit-convention / Commit convention` is added to this repository's branch protection — that step is not part of this pull request.