### PR TITLE
Align the commit-subject rule with the wired gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,31 +118,49 @@ Pipeline (`make release X.Y.Z`):
 
 ## PR/commit checklist
 - `composer ci:test` must pass before every commit.
-- A subject starting with `GH-` must match `^GH-\d+: [A-ZÄÖÜ]`; every other subject
-  must match `^[A-ZÄÖÜ]` — a capitalised imperative either way. The patterns check
-  only the leading capital; two starts are banned whatever their case:
-  **conventional-commit prefixes** (`feat:`, `Fix:`, `chore:` …) and path-like starts
-  (`src/Module.php: …`, `Src/Module.php: …`).
-    - The two patterns are deliberately kept separate: `^(GH-\d+: )?[A-ZÄÖÜ]` (wrong)
-      stops enforcing the capital *after* the prefix, because the optional group can
-      be skipped and the `G` of `GH-` then satisfies `[A-ZÄÖÜ]` on its own —
-      `GH-12: fix typo` would pass. Keying on the subject rather than on the branch
-      also keeps this check decidable for commits already on `main`, where the issue
-      branch no longer exists.
-    - The same two patterns apply to the **pull-request title**, which under
-      squash-merge is the subject that reaches `main`.
-    - The normative definition lives in
-      `magicsunday/.github/.github/workflows/commit-convention.yml@main`, which
-      self-tests a decision table before applying it. No workflow here calls that
-      gate, so the rule in this repository is documentation only; wherever it is
-      wired, the workflow is authoritative and this text is what gets fixed.
+- Commit subjects and the pull-request title are enforced by
+  `.github/workflows/commit-lint.yml`, which calls
+  `magicsunday/.github/.github/workflows/commit-convention.yml@main`. That workflow
+  holds the normative rule and self-tests it against a decision table before applying
+  it; where this summary and the workflow disagree, the workflow is authoritative on
+  what is *accepted* and this text is what gets fixed — except where this text is
+  deliberately narrower about what is *written* (ASCII `[A-Z]`, below). The invariant to
+  preserve is that this text must never accept a subject the workflow blocks. Both the
+  title and every commit in the pull request are judged, because which of them reaches
+  `main` depends on how the pull request lands: a multi-commit squash uses the title, a
+  single-commit squash keeps that commit's own subject, and a merge or rebase merge
+  keeps the commits' subjects. Checking both makes the rule hold either way. The message
+  body and existing history are never judged. The check is advisory until
+  `commit-convention / Commit convention` is a required context in branch protection.
+- The rule in short: a subject starting with `GH-` must match `^GH-\d+: [A-Z]`, every
+  other subject `^[A-Z]` — a capitalised imperative either way. Two starts are rejected
+  whatever their case: **conventional-commit prefixes**, including the capitalised
+  `Fix:` and the scoped breaking-change `Feat(api)!:` as much as a plain `feat:`, and
+  **path-like starts** such as `src/Module.php: …` and the capitalised
+  `Src/Module.php:fix` — no space after the colon is needed to count. Subjects beginning
+  `Merge ` or `Revert ` pass — by prefix rather than by provenance, and in any case on
+  their leading capital, since neither ban can fire on them: the path ban needs a slash
+  before the first colon with no whitespace in between, and the conventional-commit ban
+  needs one of its type words followed immediately by an optional scope or `!` and then
+  a colon — these have a space there. The same check judges the pull-request title, so
+  never title a pull request `Merge …`. `fixup!` and `squash!` do not pass, so
+  autosquash them before opening the PR. Commit subjects are English, so the documented
+  capital is ASCII `[A-Z]`, while the gate accepts the wider `[[:upper:]]` under the
+  UTF-8 locale it pins — under `LC_ALL=C` that width disappears. The width only ever
+  adds PASSes: the class sits in two accept positions, and its third use — lowercasing
+  the subject before the conventional-commit test — is byte-based and touches ASCII
+  only. This holds for the capital class alone: the gate is **not** a superset of
+  `^[A-Z]`, because the `GH-` routing and the two banned starts above reject capitalised
+  subjects too.
+    - The two patterns stay separate on purpose. Folding them into
+      `^(GH-\d+: )?[A-Z]` breaks the rule: the optional group can be skipped and the
+      `G` of `GH-` then satisfies `[A-Z]` on its own, so `GH-12: fix typo` would pass.
 - Branches for an issue are named exactly `GH-<N>`, where `<N>` is the issue number.
-  The `GH-<N>: ` prefix marks work that belongs to the issue — a commit on that
-  branch whose concern is something else (a drive-by lint fix, a catalogue resync)
-  keeps its own unprefixed subject, which is what the history actually does. Merge
-  and revert commits keep the subject git generates. Not every git-written subject
-  is exempt, though: `fixup!` and `squash!` start lowercase and violate the rule, so
-  autosquash them before opening the PR.
+  The `GH-<N>: ` prefix marks work that belongs to the issue, so a commit on that
+  branch whose concern is something else — a drive-by lint fix, a dependency bump —
+  keeps its own unprefixed subject. The gate keys on the subject alone and never asks
+  which branch a commit sits on, which is what keeps it decidable for commits already
+  on `main`.
 - The PR body closes the issue with a `Closes #<N>` keyword. The `GH-<N>: ` subject
   prefix is not a GitHub link and closes nothing.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.


### PR DESCRIPTION
Rewrites the commit-subject rule in `AGENTS.md` to describe the shared
`commit-convention` gate, now wired into this repo through
`.github/workflows/commit-lint.yml`. The previous text read as "documentation
only / no workflow calls that gate" — stale since that wiring merged.

The wording is aligned in *meaning* with the other magicsunday repos (part of the
`magicsunday/webtrees-fan-chart#254` unification) while keeping this file's own
house style: spelling, bullet character, wrapping, and path examples.

Verified against the gate's own predicate — a decision table (every row
matches), an invariant (the documented `[A-Z]` never accepts a subject the gate
blocks), and a mechanism check (no ban fires on a `Merge `/`Revert ` subject).