### PR TITLE
GH-138: Adopt the shared coding-standard package and the reusable php-quality workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,17 @@ permissions:
     contents: read
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
+    # The PHP gates come from the shared reusable so the canonical step list lives
+    # in one place. Copy-paste detection stays below: jscpd is a Node tool and
+    # needs this repository's JS lane.
+    php:
+        uses: magicsunday/.github/.github/workflows/php-quality.yml@main
+        permissions:
+            contents: read
 
-        strategy:
-            fail-fast: false
-            matrix:
-                php: ['8.3', '8.4', '8.5']
+    js:
+        name: JS and release zip
+        runs-on: ubuntu-latest
 
         steps:
             - id: checkout
@@ -32,30 +36,14 @@ jobs:
                   cache: npm
 
             - id: setup_php
-              name: Set up PHP version ${{ matrix.php }}
+              name: Set up PHP
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
-                  php-version: ${{ matrix.php }}
+                  php-version: '8.3'
                   tools: composer:v2
 
             - name: Validate composer.json and composer.lock
               run: composer validate
-
-            - id: composer-cache-vars
-              name: Composer Cache Vars
-              run: |
-                  echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-                  echo "timestamp=$(date +"%s")" >> $GITHUB_OUTPUT
-
-            - id: composer-cache-dependencies
-              name: Cache Composer dependencies
-              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-              with:
-                  path: ${{ steps.composer-cache-vars.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ steps.composer-cache-vars.outputs.timestamp }}
-                  restore-keys: |
-                      ${{ runner.os }}-composer-${{ matrix.php }}-
-                      ${{ runner.os }}-composer-
 
             - id: install
               name: Install dependencies
@@ -63,69 +51,34 @@ jobs:
                   composer install --no-progress --no-interaction
                   npm ci
 
-            - id: php-lint
-              name: PHP Lint
-              if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:php:lint
-
             - id: js-lint
               name: JS Lint
               if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:js:lint
+              run: composer ci:test:js:lint
 
             - id: js-format
               name: JS Format
               if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:js:format
+              run: composer ci:test:js:format
 
             - id: js-typecheck
               name: JS Typecheck
               if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:js:typecheck
-
-            - id: phpstan
-              name: PHPStan
-              if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:php:phpstan -- --error-format=github
-
-            - id: rector
-              name: Rector
-              if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:php:rector
-
-            - id: cpd
-              name: Copy/Paste Detection
-              if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:cpd
-
-            - id: php-unit
-              name: PHP Unit Tests
-              if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:php:unit
+              run: composer ci:test:js:typecheck
 
             - id: js-unit
               name: JS Unit Tests
               if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:js:unit
+              run: composer ci:test:js:unit
 
-            - id: cgl
-              name: CGL
+            - id: cpd
+              name: Copy/Paste Detection
               if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:cgl -- --dry-run
+              run: composer ci:test:php:cpd
 
-            # Runs LAST: 'make dist' invokes 'composer install --no-dev'
-            # which strips dev packages (php-cs-fixer, phpstan, ...) from
-            # .build/vendor. Any later composer-driven step would fail.
+            # Runs LAST: 'make dist' invokes 'composer install --no-dev' which
+            # strips the dev packages from .build/vendor, so any later
+            # composer-driven step would fail.
             - id: dist-smoke
               name: Release zip smoke test
               if: ${{ success() }}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,22 +9,6 @@
 
 declare(strict_types=1);
 
-/**
- * This file represents the configuration for Code Sniffing PSR-2-related
- * automatic checks of coding guidelines Install @fabpot's great php-cs-fixer
- * tool via
- *
- *  $ composer global require friendsofphp/php-cs-fixer
- *
- * And then simply run
- *
- *  $ php-cs-fixer fix
- *
- * For more information read:
- *  http://www.php-fig.org/psr/psr-2/
- *  http://cs.sensiolabs.org
- */
-
 if (PHP_SAPI !== 'cli') {
     die('This script supports command line usage only. Please check your command.');
 }
@@ -36,87 +20,10 @@ For the full copyright and license information, please read the
 LICENSE file that was distributed with this source code.
 EOF;
 
-return (new PhpCsFixer\Config())
-    ->setCacheFile(__DIR__ . '/.build/cache/.php-cs-fixer.cache')
-    ->setRiskyAllowed(true)
-    ->setParallelConfig(new PhpCsFixer\Runner\Parallel\ParallelConfig(4, 8))
-    ->setRules([
-        '@PER-CS2x0'                      => true,
-        '@Symfony'                        => true,
+$factory = require __DIR__ . '/.build/vendor/magicsunday/coding-standard/php-cs-fixer/base.php';
 
-        // Additional custom rules
-        'declare_strict_types'            => true,
-        'concat_space'                    => [
-            'spacing' => 'one',
-        ],
-        'header_comment'                  => [
-            'header'       => $header,
-            'comment_type' => 'PHPDoc',
-            'location'     => 'after_open',
-            'separate'     => 'both',
-        ],
-        'method_argument_space'           => [
-            'on_multiline' => 'ensure_fully_multiline',
-        ],
-        'phpdoc_to_comment'               => false,
-        'phpdoc_no_alias_tag'             => false,
-        'phpdoc_annotation_without_dot'   => false,
-        'no_superfluous_phpdoc_tags'      => false,
-        'phpdoc_separation'               => [
-            'groups' => [
-                [
-                    'author',
-                    'license',
-                    'link',
-                ],
-            ],
-        ],
-        'no_alias_functions'              => true,
-        'whitespace_after_comma_in_array' => [
-            'ensure_single_space' => true,
-        ],
-        'single_line_throw'               => false,
-        'self_accessor'                   => false,
-        'global_namespace_import'         => [
-            'import_classes'   => true,
-            'import_constants' => true,
-            'import_functions' => true,
-        ],
-        'function_declaration'            => [
-            'closure_function_spacing' => 'one',
-            'closure_fn_spacing'       => 'one',
-        ],
-        'binary_operator_spaces'          => [
-            'operators' => [
-                '='   => 'align_single_space_minimal',
-                '=>'  => 'align_single_space_minimal',
-                '+='  => 'align_single_space_minimal',
-                '-='  => 'align_single_space_minimal',
-                '.='  => 'align_single_space_minimal',
-                '??=' => 'align_single_space_minimal',
-            ],
-        ],
-        'yoda_style'                      => [
-            'equal'                => false,
-            'identical'            => false,
-            'less_and_greater'     => false,
-            'always_move_variable' => false,
-        ],
-        'blank_line_before_statement'     => [
-            'statements' => [
-                'break',
-                'continue',
-                'for',
-                'foreach',
-                'if',
-                'return',
-                'switch',
-                'throw',
-                'try',
-                'while',
-            ],
-        ],
-    ])
+return $factory($header)
+    ->setCacheFile(__DIR__ . '/.build/cache/.php-cs-fixer.cache')
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->exclude([

--- a/composer.json
+++ b/composer.json
@@ -57,14 +57,9 @@
         "magicsunday/webtrees-module-installer-plugin": "^2.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.0",
+        "magicsunday/coding-standard": "^1.1",
         "overtrue/phplint": "^9.0",
-        "phpstan/phpstan": "^2.0",
-        "phpstan/phpstan-deprecation-rules": "^2.0",
-        "phpstan/phpstan-phpunit": "^2.0",
-        "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^12.0 || ^13.0",
-        "rector/rector": "^2.0"
+        "phpunit/phpunit": "^12.0 || ^13.0"
     },
     "autoload": {
         "psr-4": {
@@ -95,7 +90,7 @@
         "ci:test:php:rector": [
             "@ci:rector --dry-run"
         ],
-        "ci:test:cpd": [
+        "ci:test:php:cpd": [
             "npx jscpd src resources/js/modules --config .jscpd.json --skip-comments --no-tips"
         ],
         "ci:test:php:unit": [
@@ -123,7 +118,7 @@
             "@ci:test:js:typecheck",
             "@ci:test:php:phpstan",
             "@ci:test:php:rector",
-            "@ci:test:cpd",
+            "@ci:test:php:cpd",
             "@ci:test:php:unit",
             "@ci:test:js:unit",
             "@ci:test:php:cgl"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,13 +1,7 @@
 includes:
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-strict-rules/rules.neon
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-deprecation-rules/rules.neon
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-phpunit/extension.neon
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-phpunit/rules.neon
+    - %currentWorkingDirectory%/.build/vendor/magicsunday/coding-standard/phpstan/base.neon
 
 parameters:
-    # You can currently choose from 11 levels (0 is the loosest and 10 is the strictest).
-    level: max
-
     # PHP Version to check against (PHP 8.3 as minimum target)
     phpVersion: 80300
 
@@ -17,8 +11,11 @@ parameters:
         - %currentWorkingDirectory%/src/
         - %currentWorkingDirectory%/tests/
 
-    fileExtensions:
-        - php
-
     excludePaths:
         - %currentWorkingDirectory%/.build/
+
+services:
+    -
+        class: MagicSunday\Webtrees\DescendantsChart\Test\Architecture\ArchitectureTest
+        tags:
+            - phpat.test

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,6 +15,9 @@
     <testsuites>
         <testsuite name="Unit Tests">
             <directory>tests</directory>
+            <!-- The phpat ArchitectureTest is a PHPStan rule class, not a PHPUnit
+                 test — exclude it so PHPUnit does not warn on a non-TestCase. -->
+            <exclude>tests/Architecture</exclude>
         </testsuite>
     </testsuites>
 

--- a/rector.php
+++ b/rector.php
@@ -9,13 +9,7 @@
 
 declare(strict_types=1);
 
-use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
-use Rector\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector;
-use Rector\Set\ValueObject\LevelSetList;
-use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -25,59 +19,8 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->fileExtensions(['php', 'phtml']);
-
-    if (
-        !is_dir($concurrentDirectory = __DIR__ . '/.build/cache/.rector.cache')
-        && !mkdir($concurrentDirectory, 0775, true)
-        && !is_dir($concurrentDirectory)
-    ) {
-        throw new \RuntimeException(
-            sprintf(
-                'Directory "%s" was not created',
-                $concurrentDirectory
-            )
-        );
-    }
-
-    if (
-        !is_dir($concurrentDirectory = __DIR__ . '/.build/cache/.rector.container.cache')
-        && !mkdir($concurrentDirectory, 0775, true)
-        && !is_dir($concurrentDirectory)
-    ) {
-        throw new \RuntimeException(
-            sprintf(
-                'Directory "%s" was not created',
-                $concurrentDirectory
-            )
-        );
-    }
-
-    $rectorConfig->phpstanConfig(__DIR__ . '/phpstan.neon');
-    $rectorConfig->importNames();
-    $rectorConfig->removeUnusedImports();
-    $rectorConfig->disableParallel();
-    $rectorConfig->cacheDirectory(__DIR__ . '/.build/cache/.rector.cache');
-    $rectorConfig->containerCacheDirectory(__DIR__ . '/.build/cache/.rector.container.cache');
     $rectorConfig->phpVersion(80300);
+    $rectorConfig->phpstanConfig(__DIR__ . '/phpstan.neon');
 
-    // Define what rule sets will be applied
-    $rectorConfig->sets([
-        SetList::CODE_QUALITY,
-        SetList::CODING_STYLE,
-        SetList::DEAD_CODE,
-        SetList::EARLY_RETURN,
-        SetList::INSTANCEOF,
-        SetList::PRIVATIZATION,
-        SetList::TYPE_DECLARATION,
-        SetList::TYPE_DECLARATION_DOCBLOCKS,
-        LevelSetList::UP_TO_PHP_83,
-    ]);
-
-    // Skip some rules
-    $rectorConfig->skip([
-        CatchExceptionNameMatchingTypeRector::class,
-        RemoveUnreachableStatementRector::class,
-        RemoveUselessParamTagRector::class,
-        RemoveUselessReturnTagRector::class,
-    ]);
+    (require __DIR__ . '/.build/vendor/magicsunday/coding-standard/rector/base.php')($rectorConfig);
 };

--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-descendants-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\DescendantsChart\Test\Architecture;
+
+use PHPat\Selector\Selector;
+use PHPat\Test\Attributes\TestRule;
+use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
+
+/**
+ * Architecture rules enforced by PHPat (runs as part of PHPStan).
+ *
+ * The module is layered bottom-up: `Model` and `Configuration` are leaves,
+ * `Traits` may reach `Configuration`, `Facade` may reach `Configuration` and
+ * `Model`, and `Module` is the composition root nothing else depends on. The
+ * rules below pin exactly that, so a dependency that inverts the layering reds
+ * the build instead of quietly settling in.
+ *
+ * Note on the builder: several selectors passed to `classes()` are OR-ed, so a
+ * "everything except X" set is expressed with the dedicated `excluding()` step,
+ * never with a negated selector inside `classes()`.
+ *
+ * @internal
+ */
+final class ArchitectureTest
+{
+    /**
+     * The module's root namespace.
+     */
+    private const string NAMESPACE_ROOT = 'MagicSunday\Webtrees\DescendantsChart';
+
+    /**
+     * Every abstract class carries the `Abstract` name prefix. The pattern is
+     * matched against the fully qualified name, so `[^\\]*$` pins it to the
+     * short class name rather than any namespace segment.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function abstractClassesAreAbstractPrefixed(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::isAbstract())
+            ->should()->beNamed('/\\\\Abstract[^\\\\]*$/', true)
+            ->because('House rule: abstract classes are named Abstract<Name>.');
+    }
+
+    /**
+     * The chart node models carry data only — they must not reach back into the
+     * configuration, the facade, the traits or the module.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function modelIsALeaf(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Model'))
+            ->shouldNot()->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
+            ->excluding(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Model'))
+            ->because('Model holds chart data; it is the bottom layer.');
+    }
+
+    /**
+     * The resolved chart configuration is a leaf as well: it reads module
+     * settings, it does not consume any other part of the module.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function configurationIsALeaf(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::classname(self::NAMESPACE_ROOT . '\\Configuration'))
+            ->shouldNot()->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
+            ->excluding(Selector::classname(self::NAMESPACE_ROOT . '\\Configuration'))
+            ->because('Configuration is a settings holder, not a consumer of the module.');
+    }
+
+    /**
+     * The module traits are mixed into the module class and may read the
+     * configuration — but never the models, the facade or the module itself.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function traitsDependOnlyOnConfiguration(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Traits'))
+            ->shouldNot()->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
+            ->excluding(
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Traits'),
+                Selector::classname(self::NAMESPACE_ROOT . '\\Configuration')
+            )
+            ->because('Traits configure the module; they may only read Configuration.');
+    }
+
+    /**
+     * The data facade builds the chart models from the resolved configuration.
+     * It must not reach the module traits or the module class.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function facadeDependsOnlyOnConfigurationAndModel(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Facade'))
+            ->shouldNot()->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
+            ->excluding(
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Facade'),
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Model'),
+                Selector::classname(self::NAMESPACE_ROOT . '\\Configuration')
+            )
+            ->because('The facade turns Configuration plus webtrees data into Model objects.');
+    }
+
+    /**
+     * The module class is the composition root — the webtrees entry point that
+     * wires the rest together. No production class may depend on it. The test
+     * namespace is excluded: a test for the module class necessarily names it.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function nothingDependsOnTheModule(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
+            ->excluding(
+                Selector::classname(self::NAMESPACE_ROOT . '\\Module'),
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Test')
+            )
+            ->shouldNot()->dependOn()
+            ->classes(Selector::classname(self::NAMESPACE_ROOT . '\\Module'))
+            ->because('Module is the composition root; dependencies point away from it.');
+    }
+}


### PR DESCRIPTION
Closes #138. Closes #135.

Replaces this repository's local copies of the php-cs-fixer ruleset, the PHPStan configuration and the Rector rule set with the shared `magicsunday/coding-standard` package, and moves the PHP gate step list to the shared reusable workflow. Same adoption as the pedigree chart, whose layering this module matches exactly.

## Dependencies

`magicsunday/coding-standard: ^1.1` replaces the individual tool requirements it provides (php-cs-fixer, PHPStan and its three rule packs, Rector). `overtrue/phplint` and PHPUnit stay repo-local.

## Configs

- `.php-cs-fixer.dist.php` calls the shared factory and keeps its own header and finder — this repo also lints `resources/views/` and `*.phtml`.
- `phpstan.neon` includes the shared base (`level: max`, `treatPhpDocTypesAsCertain: false`, the rule packs and phpat) and keeps the repo's own paths, PHP version and cache dir.
- `rector.php` applies the shared rule sets and keeps the repo's paths, PHP version and file extensions.
- `ci:test:cpd` is renamed to the canonical `ci:test:php:cpd`; the aggregate follows.

## phpat (closes #135)

`tests/Architecture/ArchitectureTest.php` pins the layering this module actually has, derived from its imports rather than assumed: `Model` and `Configuration` are leaves, `Traits` may reach only `Configuration`, `Facade` may reach only `Configuration` and `Model`, and nothing depends on `Module` (the composition root). Plus the house rule that abstract classes are named `Abstract<Name>`.

The rules were verified to discriminate rather than merely load: adding a real dependency from `Model\CoupleNode` to `Configuration` makes `modelIsALeaf` fail with exactly one finding, and removing it returns the suite to green. A green architecture suite that cannot fail is worth nothing.

`beFinal` is deliberately not included — every class here is currently non-final, so those rules would fail. That is tracked separately, mirroring the pedigree chart.

## CI

The PHP gates now come from the reusable `php-quality` workflow. The JS lane, copy-paste detection (jscpd is a Node tool) and the release-zip smoke test stay in this repository's workflow. The branch-protection required-checks list has to be updated in the same step, because a reusable reports its checks as `<caller job> / <reusable job> (<matrix>)`.

## Verification

`composer ci:test` green locally (PHPStan incl. the six phpat rules, Rector, CGL, 0 clones, 13 PHP tests, 12 JS tests).
