### PR TITLE
GH-141: Drop the Traits layer rule that phpat can never evaluate

### DIFF
--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -29,6 +29,13 @@ use PHPat\Test\PHPat;
  * "everything except X" set is expressed with the dedicated `excluding()` step,
  * never with a negated selector inside `classes()`.
  *
+ * Scope limit: the `Traits` layer cannot be the SUBJECT of a rule. phpat resolves
+ * a subject through PHPStan's `InClassNode`, which never fires for a trait on its
+ * own, so such a rule matches nothing and passes green regardless — it would imply
+ * coverage that does not exist. The traits stay pinned in the incoming direction
+ * (the leaf rules below forbid the other layers from depending on them); only
+ * their outgoing dependencies are unenforceable here.
+ *
  * @internal
  */
 final class ArchitectureTest
@@ -86,26 +93,6 @@ final class ArchitectureTest
             ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
             ->excluding(Selector::classname(self::NAMESPACE_ROOT . '\\Configuration'))
             ->because('Configuration is a settings holder, not a consumer of the module.');
-    }
-
-    /**
-     * The module traits are mixed into the module class and may read the
-     * configuration — but never the models, the facade or the module itself.
-     *
-     * @return Rule
-     */
-    #[TestRule]
-    public function traitsDependOnlyOnConfiguration(): Rule
-    {
-        return PHPat::rule()
-            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Traits'))
-            ->shouldNot()->dependOn()
-            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
-            ->excluding(
-                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Traits'),
-                Selector::classname(self::NAMESPACE_ROOT . '\\Configuration')
-            )
-            ->because('Traits configure the module; they may only read Configuration.');
     }
 
     /**


### PR DESCRIPTION
Closes #141.

`traitsDependOnlyOnConfiguration` used the `Traits` namespace as its rule subject. That namespace holds only traits, and phpat resolves a subject through PHPStan's `InClassNode`, which never fires for a trait on its own — PHPStan analyses a trait only inside the class that uses it. The rule matched nothing and passed green regardless of what the traits actually depended on.

Verified rather than argued: adding a forbidden dependency from `Traits\ModuleChartTrait` to `Model\CoupleNode` left the run reporting `No errors`.

Removing it is the honest fix — a rule that cannot fail is worse than no rule, because the file implies coverage that is not there. The class docblock now states the scope limit: the traits stay pinned in the *incoming* direction, since the leaf rules forbid the other layers from depending on them; only their outgoing dependencies are unenforceable.

## The remaining five rules were proven to fire

A break test with four simultaneous violations — `Configuration` → `Model\CoupleNode`, `Facade\DataFacade` → `Traits\ModuleChartTrait`, `Model\NodeData` → `Module`, and an `abstract class BadlyNamedBase` — makes every one of them report under its own name:

```
phpat.abstractClassesAreAbstractPrefixed
phpat.configurationIsALeaf
phpat.facadeDependsOnlyOnConfigurationAndModel
phpat.modelIsALeaf
phpat.nothingDependsOnTheModule
```

Reverting the injections returns the suite to green. This is the check that should have run before the rules were merged in the first place — a green PHPStan run is indistinguishable from a rule that selects nothing.

## Verification

`composer ci:test` green (PHPStan incl. the five phpat rules, Rector, CGL, 0 clones, 13 PHP tests, 12 JS tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the limitations around validating PHP trait dependencies in architecture rules.

* **Tests**
  * Removed an unsupported trait dependency rule to prevent misleadingly passing architecture checks.
  * Retained the remaining dependency rules for application layers such as configuration, models, facades, and modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->