### PR TITLE
GH-143: Adopt coding-standard 1.3.0 — drop phplint/phpunit and version the Rector factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,9 +57,7 @@
         "magicsunday/webtrees-module-installer-plugin": "^2.0"
     },
     "require-dev": {
-        "magicsunday/coding-standard": "^1.1",
-        "overtrue/phplint": "^9.0",
-        "phpunit/phpunit": "^12.0 || ^13.0"
+        "magicsunday/coding-standard": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/rector.php
+++ b/rector.php
@@ -19,8 +19,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->fileExtensions(['php', 'phtml']);
-    $rectorConfig->phpVersion(80300);
     $rectorConfig->phpstanConfig(__DIR__ . '/phpstan.neon');
 
-    (require __DIR__ . '/.build/vendor/magicsunday/coding-standard/rector/base.php')($rectorConfig);
+    (require __DIR__ . '/.build/vendor/magicsunday/coding-standard/rector/base.php')($rectorConfig, 80300);
 };


### PR DESCRIPTION
Closes #143.

Brings the module onto the published coding-standard 1.3.0. `require-dev` collapses to the single `magicsunday/coding-standard: ^1.3` entry — `overtrue/phplint` and `phpunit/phpunit` now arrive transitively (phplint was always in the package `require`; PHPUnit was added in 1.3.0). `rector.php` states the PHP floor once through the factory: `(require '.../rector/base.php')($rectorConfig, 80300)`.

No behaviour change. Verified green via the buildbox on 1.3.0:

| Gate | Result |
|---|---|
| transitive resolve | coding-standard 1.3.0, phplint 9.7.2, phpunit 13.2.4 |
| phplint | OK (10 files) |
| phpstan (phpat) | No errors |
| rector (dry, new signature) | clean |
| php-cs-fixer (dry) | 0 of 26 fixable |
| phpunit | OK (13 tests) |

Lockstep with the fan-chart (#285/#279) and pedigree-chart (#157) adoptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development coding standards tooling.
  * Streamlined static analysis configuration and centralized PHP version setup.
  * Removed redundant development-only testing and linting packages.

* **Impact**
  * No changes to end-user functionality or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->